### PR TITLE
Add API request protection middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ DB_PASSWORD=your_database_password
 # AI Service Configuration (Required)
 OPEN_ROUTER_API_KEY=your_openrouter_api_key
 
+# Request protection (Optional)
+# RATE_LIMIT_PER_MINUTE=60
+# MAX_REQUEST_SIZE_MB=1
+# REQUEST_TIMEOUT_SECONDS=30
+# API_AUTH_TOKEN=your_shared_token
+
 # LLM + embeddings model selection is configured in config/llm.config.ini
 # Optional overrides:
 # LLM_MODEL_NAME=your_chat_model

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,11 @@ class Settings(BaseSettings):
     VERSION: str = "0.1.0"
     API_V1_STR: str = "/api/v1"
 
+    RATE_LIMIT_PER_MINUTE: int = 60
+    MAX_REQUEST_SIZE_MB: int = 1
+    REQUEST_TIMEOUT_SECONDS: float = 30.0
+    API_AUTH_TOKEN: str = ""
+
     # API tokens
     OPEN_ROUTER_API_KEY: str = os.environ.get("OPEN_ROUTER_API_KEY", "")
     SUPABASE_PASSWORD: str = os.environ.get("SUPABASE_PASSWORD", "")

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from typing import Deque
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.status import (
+    HTTP_401_UNAUTHORIZED,
+    HTTP_413_CONTENT_TOO_LARGE,
+    HTTP_429_TOO_MANY_REQUESTS,
+    HTTP_504_GATEWAY_TIMEOUT,
+)
+
+
+class AuthTokenMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, token: str) -> None:
+        super().__init__(app)
+        self._token = token.strip()
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        if not self._token:
+            return await call_next(request)
+
+        header_token = request.headers.get("x-api-token")
+        bearer = request.headers.get("authorization", "")
+        if bearer.lower().startswith("bearer "):
+            bearer = bearer.split(" ", 1)[1].strip()
+        else:
+            bearer = ""
+
+        if header_token != self._token and bearer != self._token:
+            return JSONResponse(
+                {"detail": "Unauthorized"},
+                status_code=HTTP_401_UNAUTHORIZED,
+            )
+
+        return await call_next(request)
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app,
+        requests_per_minute: int,
+    ) -> None:
+        super().__init__(app)
+        self._limit = max(1, requests_per_minute)
+        self._window_seconds = 60.0
+        self._buckets: dict[str, Deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        client_ip = _get_client_ip(request)
+        now = time.monotonic()
+
+        async with self._lock:
+            bucket = self._buckets.get(client_ip)
+            if bucket is None:
+                bucket = deque()
+                self._buckets[client_ip] = bucket
+
+            while bucket and now - bucket[0] > self._window_seconds:
+                bucket.popleft()
+
+            if len(bucket) >= self._limit:
+                retry_after = int(self._window_seconds - (now - bucket[0]))
+                retry_after = max(1, retry_after)
+                return JSONResponse(
+                    {"detail": "Rate limit exceeded"},
+                    status_code=HTTP_429_TOO_MANY_REQUESTS,
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            bucket.append(now)
+
+        return await call_next(request)
+
+
+class RequestTimeoutMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, timeout_seconds: float) -> None:
+        super().__init__(app)
+        self._timeout_seconds = max(0.1, timeout_seconds)
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        try:
+            return await asyncio.wait_for(
+                call_next(request), timeout=self._timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            return JSONResponse(
+                {"detail": "Request timed out"},
+                status_code=HTTP_504_GATEWAY_TIMEOUT,
+            )
+
+
+class RequestSizeLimitMiddleware:
+    def __init__(self, app, max_body_size_bytes: int) -> None:
+        self.app = app
+        self._max_body_size = max(1, max_body_size_bytes)
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = {
+            key.decode("latin-1").lower(): value.decode("latin-1")
+            for key, value in scope.get("headers", [])
+        }
+        content_length = headers.get("content-length")
+        if content_length and content_length.isdigit():
+            if int(content_length) > self._max_body_size:
+                await _send_size_limit_response(scope, receive, send)
+                return
+
+        buffered_messages = []
+        received = 0
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                continue
+            body = message.get("body", b"")
+            received += len(body)
+            if received > self._max_body_size:
+                await _send_size_limit_response(scope, receive, send)
+                return
+            buffered_messages.append(message)
+            if not message.get("more_body", False):
+                break
+
+        async def receive_wrapper():
+            if buffered_messages:
+                return buffered_messages.pop(0)
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        await self.app(scope, receive_wrapper, send)
+
+
+def _get_client_ip(request: Request) -> str:
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+async def _send_size_limit_response(scope, receive, send) -> None:
+    response = JSONResponse(
+        {"detail": "Request too large"},
+        status_code=HTTP_413_CONTENT_TOO_LARGE,
+    )
+    await response(scope=scope, receive=receive, send=send)

--- a/app/tests/clients/base_client.py
+++ b/app/tests/clients/base_client.py
@@ -3,6 +3,7 @@ Base client class for API testing.
 """
 
 import requests
+import os
 from typing import Any, Dict, Optional
 
 from app.tests.utils.constants import REQUEST_TIMEOUT
@@ -14,6 +15,7 @@ class BaseAPIClient:
     def __init__(self, base_url: str):
         self.base_url = base_url
         self.timeout = REQUEST_TIMEOUT
+        self.auth_token = os.getenv("API_AUTH_TOKEN", "")
 
     def _make_request(
         self,
@@ -36,6 +38,8 @@ class BaseAPIClient:
         """
         url = f"{self.base_url}{endpoint}"
         default_headers = {"Content-Type": "application/json"}
+        if self.auth_token:
+            default_headers["X-API-Token"] = self.auth_token
         if headers:
             default_headers.update(headers)
 

--- a/app/tests/unit/test_request_protection_middleware.py
+++ b/app/tests/unit/test_request_protection_middleware.py
@@ -1,0 +1,91 @@
+import asyncio
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.middleware import (
+    AuthTokenMiddleware,
+    RateLimitMiddleware,
+    RequestSizeLimitMiddleware,
+    RequestTimeoutMiddleware,
+)
+
+
+def build_app(
+    *,
+    token: str = "",
+    rate_limit: int = 100,
+    max_body_bytes: int = 1024,
+    timeout_seconds: float = 1.0,
+) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/ok")
+    async def ok() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/echo")
+    async def echo() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/slow")
+    async def slow() -> dict[str, bool]:
+        await asyncio.sleep(0.2)
+        return {"ok": True}
+
+    app.add_middleware(RequestTimeoutMiddleware, timeout_seconds=timeout_seconds)
+    app.add_middleware(AuthTokenMiddleware, token=token)
+    app.add_middleware(
+        RateLimitMiddleware,
+        requests_per_minute=rate_limit,
+    )
+    app.add_middleware(RequestSizeLimitMiddleware, max_body_size_bytes=max_body_bytes)
+
+    return app
+
+
+def test_auth_token_required() -> None:
+    client = TestClient(build_app(token="secret"))
+
+    assert client.get("/ok").status_code == 401
+    assert client.get("/ok", headers={"X-API-Token": "secret"}).status_code == 200
+
+
+def test_rate_limit_applies_to_unauthorized_requests() -> None:
+    client = TestClient(build_app(token="secret", rate_limit=1))
+
+    first = client.get("/ok")
+    second = client.get("/ok")
+
+    assert first.status_code == 401
+    assert second.status_code == 429
+
+
+def test_request_size_limit_blocks_large_payloads() -> None:
+    client = TestClient(build_app(max_body_bytes=4))
+
+    response = client.post(
+        "/echo",
+        content=b"12345",
+        headers={"Content-Type": "application/octet-stream"},
+    )
+
+    assert response.status_code == 413
+
+
+def test_request_timeout_returns_504() -> None:
+    client = TestClient(build_app(timeout_seconds=0.05))
+
+    response = client.get("/slow")
+
+    assert response.status_code == 504
+
+
+def test_rate_limit_ignores_forwarded_for() -> None:
+    client = TestClient(build_app(rate_limit=1))
+
+    first = client.get("/ok", headers={"X-Forwarded-For": "1.1.1.1"})
+    second = client.get("/ok", headers={"X-Forwarded-For": "2.2.2.2"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429


### PR DESCRIPTION
## Summary
Adds first-pass request protection at the FastAPI middleware layer for public API deployment.

This PR introduces:
- Shared-token auth gate (`API_AUTH_TOKEN`) using `X-API-Token` or `Authorization: Bearer ...`
- Per-IP in-memory rate limiting (`RATE_LIMIT_PER_MINUTE`, default `60`)
- Request body size limit (`MAX_REQUEST_SIZE_MB`, default `1`)
- Request timeout guard (`REQUEST_TIMEOUT_SECONDS`, default `30`)
- Startup logging to clearly indicate request-protection settings and whether auth is enabled

## Middleware Behavior
Middleware is wired in `app/main.py` so protections run in this order from outer to inner:
1. `RequestSizeLimitMiddleware`
2. `RateLimitMiddleware`
3. `AuthTokenMiddleware`
4. `RequestTimeoutMiddleware`

Implications:
- Oversized payloads are rejected before request handlers run.
- Rate limiting applies to **all** traffic, including unauthorized requests.
- Auth is required only when `API_AUTH_TOKEN` is configured (non-empty).
- Timeout applies to endpoint processing and returns `504` when exceeded.

## Security Notes
- Rate limiting uses socket client IP and **does not trust `X-Forwarded-For`**.
- This avoids spoofing-by-header bypass for the limiter.

## Configuration and Docs
Updated settings in `app/core/config.py`:
- `RATE_LIMIT_PER_MINUTE=60`
- `MAX_REQUEST_SIZE_MB=1`
- `REQUEST_TIMEOUT_SECONDS=30.0`
- `API_AUTH_TOKEN=""` (disabled by default)

Updated docs in `README.md` with these optional env vars.

## Test Coverage Added
New unit test module: `app/tests/unit/test_request_protection_middleware.py`
- `401` when token required and missing
- `429` after limit reached, including for unauthorized requests
- `413` when body exceeds max size
- `504` when request exceeds timeout
- `X-Forwarded-For` ignored by limiter

Also updated test API client (`app/tests/clients/base_client.py`) to auto-send `X-API-Token` when `API_AUTH_TOKEN` is set, so e2e/live tests work with auth enabled.

## Validation
Executed:
- `.venv/bin/pytest -q`

Result:
- `18 passed, 1 warning`
- Warning is existing upstream OpenAI/Pydantic compatibility notice on Python 3.14.
