### PR TITLE
Stabilize flaky grocery and pagination e2e tests

### DIFF
--- a/app/core/prompts.py
+++ b/app/core/prompts.py
@@ -141,6 +141,8 @@ Return ONLY valid JSON in this schema:
 
 Rules:
 - Combine duplicate ingredients into a single consolidated grocery item.
+- Preserve coverage: every distinct ingredient concept from input should appear at
+  least once in output (merge true duplicates/synonyms, do not omit).
 - Keep quantities when clear (for example "2 cups flour"), and merge quantities
   when possible.
 - Use concise, shopper-friendly ingredient lines.

--- a/app/tests/e2e/test_recipe_grocery_list.py
+++ b/app/tests/e2e/test_recipe_grocery_list.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+from app.api.schemas import Recipe
+from app.services.data.managers.recipe_manager import RecipeManager
 from app.tests.clients.api_client import APIClient
 from app.tests.utils.constants import HTTP_OK
 from app.tests.utils.helpers import maybe_throttle
@@ -9,52 +11,46 @@ from app.tests.utils.helpers import maybe_throttle
 
 def test_create_grocery_list_from_two_recipes(api_client: APIClient) -> None:
     run_id = uuid.uuid4().hex[:8]
-    recipe_one_input = (
-        f"Groceries Pasta {run_id}\n\n"
-        "Servings: 2\n"
-        "Total time: 20 minutes\n\n"
-        "Ingredients:\n- 200g pasta\n- 2 tomatoes\n- 2 cloves garlic\n"
-        f"- 1 tsp spice-{run_id}\n\n"
-        "Instructions:\n1. Boil pasta.\n2. Cook tomatoes and garlic.\n"
-        "3. Mix everything.\n"
+    recipe_manager = RecipeManager()
+    recipe_one_id = recipe_manager.create_recipe_from_model(
+        Recipe(
+            title=f"Groceries Pasta {run_id}",
+            servings="2",
+            total_time="20 minutes",
+            ingredients=[
+                "200g pasta",
+                "2 tomatoes",
+                "2 cloves garlic",
+                f"1 tsp spice-{run_id}",
+            ],
+            instructions=[
+                "Boil pasta.",
+                "Cook tomatoes and garlic.",
+                "Mix everything.",
+            ],
+        ),
+        is_test_data=True,
     )
-    recipe_two_input = (
-        f"Groceries Curry {run_id}\n\n"
-        "Servings: 3\n"
-        "Total time: 30 minutes\n\n"
-        "Ingredients:\n- 1 can chickpeas\n- 1 onion\n- 1 tsp cumin\n"
-        f"- 1 tsp herb-{run_id}\n\n"
-        "Instructions:\n1. Saute onion.\n2. Add chickpeas and cumin.\n"
-        "3. Simmer and serve.\n"
+    recipe_two_id = recipe_manager.create_recipe_from_model(
+        Recipe(
+            title=f"Groceries Curry {run_id}",
+            servings="3",
+            total_time="30 minutes",
+            ingredients=[
+                "1 can chickpeas",
+                "1 onion",
+                "1 tsp cumin",
+                f"1 tsp herb-{run_id}",
+            ],
+            instructions=[
+                "Saute onion.",
+                "Add chickpeas and cumin.",
+                "Simmer and serve.",
+            ],
+        ),
+        is_test_data=True,
     )
-
-    recipe_one_id = None
-    recipe_two_id = None
     try:
-        maybe_throttle()
-        create_one_response = api_client.recipes.process_and_store_recipe(
-            recipe_one_input,
-            enforce_deduplication=False,
-        )
-        assert create_one_response["status_code"] == HTTP_OK
-        create_one_data = create_one_response["data"]
-        assert create_one_data.get("success") is True
-        assert create_one_data.get("created") is True
-        recipe_one_id = create_one_data.get("recipe_id")
-        assert recipe_one_id
-
-        maybe_throttle()
-        create_two_response = api_client.recipes.process_and_store_recipe(
-            recipe_two_input,
-            enforce_deduplication=False,
-        )
-        assert create_two_response["status_code"] == HTTP_OK
-        create_two_data = create_two_response["data"]
-        assert create_two_data.get("success") is True
-        assert create_two_data.get("created") is True
-        recipe_two_id = create_two_data.get("recipe_id")
-        assert recipe_two_id
-
         maybe_throttle()
         grocery_response = api_client.recipes.create_grocery_list(
             [recipe_one_id, recipe_two_id]
@@ -83,6 +79,6 @@ def test_create_grocery_list_from_two_recipes(api_client: APIClient) -> None:
         )
     finally:
         if recipe_one_id:
-            api_client.recipes.delete_recipe(recipe_one_id)
+            recipe_manager.delete_recipe(recipe_one_id)
         if recipe_two_id:
-            api_client.recipes.delete_recipe(recipe_two_id)
+            recipe_manager.delete_recipe(recipe_two_id)

--- a/app/tests/e2e/test_recipe_list_pagination.py
+++ b/app/tests/e2e/test_recipe_list_pagination.py
@@ -1,62 +1,35 @@
 """E2E coverage for cursor pagination on recipe listing."""
 
-import uuid
-
 from app.tests.clients.api_client import APIClient
 from app.tests.utils.constants import HTTP_OK
-from app.tests.utils.helpers import maybe_throttle
 
 
 def test_list_recipes_paginates_with_unique_ids(api_client: APIClient) -> None:
-    run_id = uuid.uuid4().hex[:8]
-    created_recipe_ids: list[str] = []
     paged_recipe_ids: list[str] = []
+    seen_cursors: set[str] = set()
     cursor: str | None = None
 
-    try:
-        for index in range(5):
-            maybe_throttle()
-            create_response = api_client.recipes.process_and_store_recipe(
-                (
-                    f"Pagination Test Recipe {index} {run_id}\n\n"
-                    "Servings: 2\n"
-                    "Total time: 20 minutes\n\n"
-                    "Ingredients:\n- 200g pasta\n- 1 tbsp olive oil\n"
-                    f"- 1 tsp pagination-marker-{run_id}-{index}\n\n"
-                    "Instructions:\n1. Boil pasta.\n2. Toss and serve.\n"
-                ),
-                enforce_deduplication=False,
-            )
-            assert create_response["status_code"] == HTTP_OK
-            create_data = create_response["data"]
-            assert create_data.get("success") is True
-            assert create_data.get("created") is True
-            recipe_id = create_data.get("recipe_id")
-            assert isinstance(recipe_id, str)
-            created_recipe_ids.append(recipe_id)
+    for page_index in range(5):
+        list_response = api_client.recipes.list_recipes(limit=1, cursor=cursor)
+        assert list_response["status_code"] == HTTP_OK
+        list_data = list_response["data"]
+        assert list_data.get("success") is True
 
-        for page_index in range(5):
-            maybe_throttle()
-            list_response = api_client.recipes.list_recipes(limit=1, cursor=cursor)
-            assert list_response["status_code"] == HTTP_OK
-            list_data = list_response["data"]
-            assert list_data.get("success") is True
+        recipes = list_data.get("recipes")
+        assert isinstance(recipes, list)
+        assert len(recipes) == 1, "Expected at least 5 recipes to exist in the DB"
 
-            recipes = list_data.get("recipes")
-            assert isinstance(recipes, list)
-            assert len(recipes) == 1
+        recipe_id = recipes[0].get("id")
+        assert isinstance(recipe_id, str)
+        paged_recipe_ids.append(recipe_id)
 
-            recipe_id = recipes[0].get("id")
-            assert isinstance(recipe_id, str)
-            paged_recipe_ids.append(recipe_id)
+        next_cursor = list_data.get("next_cursor")
+        if page_index < 4:
+            assert isinstance(next_cursor, str)
+            assert next_cursor
+            assert next_cursor not in seen_cursors
+            seen_cursors.add(next_cursor)
+        cursor = next_cursor
 
-            cursor = list_data.get("next_cursor")
-            if page_index < 4:
-                assert isinstance(cursor, str)
-                assert cursor
-
-        assert len(paged_recipe_ids) == 5
-        assert len(set(paged_recipe_ids)) == 5
-    finally:
-        for recipe_id in created_recipe_ids:
-            api_client.recipes.delete_recipe(recipe_id)
+    assert len(paged_recipe_ids) == 5
+    assert len(set(paged_recipe_ids)) == 5


### PR DESCRIPTION
This PR removes unnecessary LLM-heavy setup from two flaky e2e tests and keeps their assertions focused on endpoint behavior. The pagination test now validates five unique IDs via cursor paging without creating recipes first, and it guards against repeated cursors. The grocery-list test now seeds deterministic recipes directly via RecipeManager, so only grocery aggregation remains under test. It also strengthens the grocery aggregation system prompt to preserve distinct ingredient concepts instead of dropping them. Unit checks for grocery aggregation/endpoint and Ruff checks pass; live e2e execution still requires configured secrets.