### PR TITLE
Add client-side grocery bag checkout MVP

### DIFF
--- a/apps/web/src/app/api/recipes/grocery-list/route.test.ts
+++ b/apps/web/src/app/api/recipes/grocery-list/route.test.ts
@@ -1,0 +1,113 @@
+/** @vitest-environment node */
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createGroceryListMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
+  createGroceryListMock: vi.fn(),
+  isForkfolioApiErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/forkfolio-api", () => ({
+  createGroceryList: createGroceryListMock,
+  isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+import { POST } from "./route";
+
+describe("POST /api/recipes/grocery-list", () => {
+  beforeEach(() => {
+    createGroceryListMock.mockReset();
+    isForkfolioApiErrorMock.mockReset();
+    isForkfolioApiErrorMock.mockReturnValue(false);
+  });
+
+  it("returns 400 when recipe_ids is missing", async () => {
+    const request = new NextRequest("http://localhost:3000/api/recipes/grocery-list", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      detail: "recipe_ids must be a non-empty array of recipe IDs.",
+    });
+    expect(createGroceryListMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 when recipe_ids resolves to empty IDs", async () => {
+    const request = new NextRequest("http://localhost:3000/api/recipes/grocery-list", {
+      method: "POST",
+      body: JSON.stringify({ recipe_ids: ["", "   "] }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      detail: "recipe_ids must include at least one recipe ID.",
+    });
+    expect(createGroceryListMock).not.toHaveBeenCalled();
+  });
+
+  it("trims, deduplicates, and forwards recipe IDs", async () => {
+    createGroceryListMock.mockResolvedValue({
+      recipe_ids: ["recipe-1", "recipe-2"],
+      ingredients: ["1 onion", "2 tomatoes"],
+      count: 2,
+      success: true,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/recipes/grocery-list", {
+      method: "POST",
+      body: JSON.stringify({
+        recipe_ids: [" recipe-1 ", "recipe-2", "recipe-1"],
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(createGroceryListMock).toHaveBeenCalledWith({
+      recipe_ids: ["recipe-1", "recipe-2"],
+    });
+  });
+
+  it("maps Forkfolio API errors", async () => {
+    const apiError = {
+      status: 404,
+      detail: "Recipes not found: recipe-9",
+      message: "Recipes not found: recipe-9",
+    };
+
+    createGroceryListMock.mockRejectedValue(apiError);
+    isForkfolioApiErrorMock.mockImplementation((error: unknown) => error === apiError);
+
+    const request = new NextRequest("http://localhost:3000/api/recipes/grocery-list", {
+      method: "POST",
+      body: JSON.stringify({ recipe_ids: ["recipe-9"] }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      detail: "Recipes not found: recipe-9",
+    });
+  });
+});

--- a/apps/web/src/app/api/recipes/grocery-list/route.ts
+++ b/apps/web/src/app/api/recipes/grocery-list/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createGroceryList, isForkfolioApiError } from "@/lib/forkfolio-api";
+import type { CreateGroceryListRequest } from "@/lib/forkfolio-types";
+
+const MAX_RECIPE_IDS = 100;
+
+type GroceryListRoutePayload = {
+  recipe_ids?: unknown;
+};
+
+type NormalizedPayloadResult =
+  | {
+      payload: CreateGroceryListRequest;
+      status: 200;
+    }
+  | {
+      detail: string;
+      status: 400 | 422;
+    };
+
+function normalizePayload(payload: GroceryListRoutePayload): NormalizedPayloadResult {
+  if (!Array.isArray(payload.recipe_ids)) {
+    return {
+      detail: "recipe_ids must be a non-empty array of recipe IDs.",
+      status: 400,
+    };
+  }
+
+  const recipeIds = payload.recipe_ids
+    .map((value) => (typeof value === "string" ? value.trim() : ""))
+    .filter((value) => value.length > 0);
+
+  const uniqueRecipeIds = [...new Set(recipeIds)];
+  if (!uniqueRecipeIds.length) {
+    return {
+      detail: "recipe_ids must include at least one recipe ID.",
+      status: 422,
+    };
+  }
+
+  if (uniqueRecipeIds.length > MAX_RECIPE_IDS) {
+    return {
+      detail: `recipe_ids cannot exceed ${MAX_RECIPE_IDS} entries.`,
+      status: 422,
+    };
+  }
+
+  return {
+    payload: {
+      recipe_ids: uniqueRecipeIds,
+    },
+    status: 200,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  let payload: unknown;
+
+  try {
+    payload = (await request.json()) as unknown;
+  } catch {
+    return NextResponse.json({ detail: "Invalid JSON payload." }, { status: 400 });
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return NextResponse.json({ detail: "Invalid JSON payload." }, { status: 400 });
+  }
+
+  const normalizedPayload = normalizePayload(payload as GroceryListRoutePayload);
+  if ("detail" in normalizedPayload) {
+    return NextResponse.json(
+      { detail: normalizedPayload.detail },
+      { status: normalizedPayload.status },
+    );
+  }
+
+  try {
+    const response = await createGroceryList(normalizedPayload.payload);
+    return NextResponse.json(response, {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    if (isForkfolioApiError(error)) {
+      return NextResponse.json(
+        { detail: error.detail ?? error.message },
+        { status: error.status },
+      );
+    }
+
+    return NextResponse.json(
+      { detail: "Failed to generate grocery list." },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/bag/page.test.tsx
+++ b/apps/web/src/app/bag/page.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GroceryBagProvider } from "@/components/grocery-bag-provider";
+
+import GroceryBagPage from "./page";
+
+function renderWithProvider() {
+  return render(
+    <GroceryBagProvider>
+      <GroceryBagPage />
+    </GroceryBagProvider>,
+  );
+}
+
+type LocalStorageMock = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+function createLocalStorageMock(): LocalStorageMock {
+  let storage: Record<string, string> = {};
+  return {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+    clear: () => {
+      storage = {};
+    },
+  };
+}
+
+describe("/bag page", () => {
+  let localStorageMock: LocalStorageMock;
+
+  beforeEach(() => {
+    localStorageMock = createLocalStorageMock();
+    vi.stubGlobal("localStorage", localStorageMock);
+    Object.defineProperty(window, "localStorage", {
+      value: localStorageMock,
+      configurable: true,
+    });
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  it("shows empty state when bag has no recipes", async () => {
+    renderWithProvider();
+
+    expect(await screen.findByText("Your bag is empty")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Generate Grocery List/i }),
+    ).toBeDisabled();
+  });
+
+  it("submits recipe IDs at checkout and renders generated list", async () => {
+    localStorageMock.setItem(
+      "forkfolio.grocery-bag.v1",
+      JSON.stringify([
+        {
+          id: "recipe-1",
+          title: "Creamy Pasta",
+          servings: "2",
+          total_time: "20 minutes",
+          added_at: "2026-03-10T01:00:00.000Z",
+        },
+        {
+          id: "recipe-2",
+          title: "Tomato Soup",
+          servings: "4",
+          total_time: "35 minutes",
+          added_at: "2026-03-10T01:05:00.000Z",
+        },
+      ]),
+    );
+
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          recipe_ids: ["recipe-1", "recipe-2"],
+          ingredients: ["1 lb pasta", "3 tomatoes"],
+          count: 2,
+          success: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    expect(await screen.findByText("Creamy Pasta")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Generate Grocery List/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/recipes/grocery-list", {
+        method: "POST",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          recipe_ids: ["recipe-1", "recipe-2"],
+        }),
+      });
+    });
+
+    expect(await screen.findByText("Your Grocery List")).toBeInTheDocument();
+    expect(await screen.findByText("1 lb pasta")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/bag/page.test.tsx
+++ b/apps/web/src/app/bag/page.test.tsx
@@ -116,4 +116,51 @@ describe("/bag page", () => {
     expect(await screen.findByText("Your Grocery List")).toBeInTheDocument();
     expect(await screen.findByText("1 lb pasta")).toBeInTheDocument();
   });
+
+  it("ignores stale generation response after bag is cleared mid-request", async () => {
+    localStorageMock.setItem(
+      "forkfolio.grocery-bag.v1",
+      JSON.stringify([
+        {
+          id: "recipe-1",
+          title: "Creamy Pasta",
+          servings: "2",
+          total_time: "20 minutes",
+          added_at: "2026-03-10T01:00:00.000Z",
+        },
+      ]),
+    );
+
+    let resolveRequest: ((response: Response) => void) | null = null;
+    const pendingRequest = new Promise<Response>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockReturnValue(pendingRequest);
+
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    expect(await screen.findByText("Creamy Pasta")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Generate Grocery List/i }));
+    await user.click(screen.getByRole("button", { name: /Clear Bag/i }));
+
+    expect(await screen.findByText("Your bag is empty")).toBeInTheDocument();
+
+    resolveRequest?.(
+      new Response(
+        JSON.stringify({
+          recipe_ids: ["recipe-1"],
+          ingredients: ["1 lb pasta"],
+          count: 1,
+          success: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText("Your Grocery List")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/app/bag/page.tsx
+++ b/apps/web/src/app/bag/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Loader2, ShoppingBag, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { useGroceryBag } from "@/components/grocery-bag-provider";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { CreateGroceryListResponse } from "@/lib/forkfolio-types";
+
+type ErrorPayload = {
+  detail?: string;
+  error?: string;
+  message?: string;
+};
+
+class BrowserApiError extends Error {
+  status: number;
+
+  detail: string | null;
+
+  constructor(message: string, status: number, detail: string | null = null) {
+    super(message);
+    this.name = "BrowserApiError";
+    this.status = status;
+    this.detail = detail;
+  }
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof BrowserApiError) {
+    return error.detail ?? error.message;
+  }
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallback;
+}
+
+async function readErrorPayload(response: Response): Promise<ErrorPayload | null> {
+  try {
+    return (await response.json()) as ErrorPayload;
+  } catch {
+    return null;
+  }
+}
+
+async function createGroceryListClient(
+  recipeIds: string[],
+): Promise<CreateGroceryListResponse> {
+  const response = await fetch("/api/recipes/grocery-list", {
+    method: "POST",
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      recipe_ids: recipeIds,
+    }),
+  });
+
+  if (!response.ok) {
+    const payload = await readErrorPayload(response);
+    const detail = payload?.detail ?? payload?.error ?? payload?.message ?? null;
+    throw new BrowserApiError(
+      detail ?? `Request failed with status ${response.status}.`,
+      response.status,
+      detail,
+    );
+  }
+
+  return (await response.json()) as CreateGroceryListResponse;
+}
+
+export default function GroceryBagPage() {
+  const { items, itemCount, removeRecipe, clearBag } = useGroceryBag();
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [generatedList, setGeneratedList] = useState<CreateGroceryListResponse | null>(
+    null,
+  );
+
+  const recipeIds = useMemo(() => items.map((item) => item.id), [items]);
+  const hasItems = itemCount > 0;
+
+  async function onGenerateGroceryList() {
+    if (!hasItems) {
+      setErrorMessage("Add at least one recipe before checkout.");
+      return;
+    }
+
+    setIsGenerating(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await createGroceryListClient(recipeIds);
+      setGeneratedList(response);
+    } catch (error) {
+      setGeneratedList(null);
+      setErrorMessage(getErrorMessage(error, "Failed to generate grocery list."));
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen">
+      <ForkfolioHeader />
+
+      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
+        <Button asChild variant="ghost" className="mb-4">
+          <Link href="/browse">
+            <ArrowLeft className="size-4" />
+            Back to Browse
+          </Link>
+        </Button>
+
+        <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
+          <div className="mx-auto max-w-5xl space-y-6">
+            <div className="space-y-3">
+              <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
+                Grocery Bag
+              </Badge>
+              <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
+                Bag then checkout
+              </h1>
+              <p className="text-lg text-muted-foreground">
+                Add recipes as you browse, then generate one combined grocery list.
+              </p>
+            </div>
+
+            <Card className="border-border/80 bg-background/85">
+              <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
+                <div>
+                  <CardTitle className="font-display text-3xl">Selected Recipes</CardTitle>
+                  <CardDescription>
+                    {itemCount} recipe{itemCount === 1 ? "" : "s"} in bag
+                  </CardDescription>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    clearBag();
+                    setGeneratedList(null);
+                    setErrorMessage(null);
+                  }}
+                  disabled={!hasItems}
+                >
+                  <Trash2 className="size-4" />
+                  Clear Bag
+                </Button>
+              </CardHeader>
+
+              <CardContent className="space-y-3">
+                {!hasItems ? (
+                  <Card>
+                    <CardHeader>
+                      <CardTitle className="text-base">Your bag is empty</CardTitle>
+                      <CardDescription>
+                        Open a recipe and use Add to Bag to start checkout.
+                      </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <Button asChild size="sm" variant="secondary">
+                        <Link href="/browse">
+                          <ShoppingBag className="size-4" />
+                          Browse Recipes
+                        </Link>
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ) : (
+                  items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/70 px-3 py-3"
+                    >
+                      <div className="min-w-0 space-y-1">
+                        <p className="truncate font-medium text-foreground">
+                          {item.title || "Untitled recipe"}
+                        </p>
+                        <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+                          {item.total_time ? (
+                            <Badge variant="outline">{item.total_time}</Badge>
+                          ) : null}
+                          {item.servings ? <Badge variant="outline">{item.servings}</Badge> : null}
+                        </div>
+                      </div>
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          removeRecipe(item.id);
+                        }}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/80 bg-background/85">
+              <CardHeader>
+                <CardTitle className="font-display text-3xl">Checkout</CardTitle>
+                <CardDescription>
+                  Generate one grocery list from all recipes in your bag.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Button
+                  type="button"
+                  onClick={() => {
+                    void onGenerateGroceryList();
+                  }}
+                  disabled={isGenerating || !hasItems}
+                >
+                  {isGenerating ? <Loader2 className="size-4 animate-spin" /> : null}
+                  {isGenerating ? "Generating..." : "Generate Grocery List"}
+                </Button>
+
+                {errorMessage ? (
+                  <Card className="border-destructive/35 bg-destructive/5">
+                    <CardHeader>
+                      <CardTitle className="text-base">Checkout failed</CardTitle>
+                      <CardDescription>{errorMessage}</CardDescription>
+                    </CardHeader>
+                  </Card>
+                ) : null}
+              </CardContent>
+            </Card>
+
+            {generatedList ? (
+              <Card className="border-primary/30 bg-primary/5">
+                <CardHeader>
+                  <CardTitle className="font-display text-3xl">Your Grocery List</CardTitle>
+                  <CardDescription>
+                    {generatedList.count} ingredient
+                    {generatedList.count === 1 ? "" : "s"} from {generatedList.recipe_ids.length}{" "}
+                    recipe{generatedList.recipe_ids.length === 1 ? "" : "s"}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2">
+                    {generatedList.ingredients.map((ingredient, index) => (
+                      <li
+                        key={`${ingredient}-${index}`}
+                        className="rounded-lg border border-border/70 bg-background/80 px-3 py-2"
+                      >
+                        {ingredient}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            ) : null}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/bag/page.tsx
+++ b/apps/web/src/app/bag/page.tsx
@@ -95,7 +95,7 @@ export default function GroceryBagPage() {
 
   async function onGenerateGroceryList() {
     if (!hasItems) {
-      setErrorMessage("Add at least one recipe before checkout.");
+      setErrorMessage("Add at least one recipe to build a grocery list.");
       return;
     }
 
@@ -132,7 +132,7 @@ export default function GroceryBagPage() {
                 Grocery Bag
               </Badge>
               <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
-                Bag then checkout
+                Bag then build list
               </h1>
               <p className="text-lg text-muted-foreground">
                 Add recipes as you browse, then generate one combined grocery list.
@@ -169,7 +169,7 @@ export default function GroceryBagPage() {
                     <CardHeader>
                       <CardTitle className="text-base">Your bag is empty</CardTitle>
                       <CardDescription>
-                        Open a recipe and use Add to Bag to start checkout.
+                        Open a recipe and use Add to Bag to start building your list.
                       </CardDescription>
                     </CardHeader>
                     <CardContent>
@@ -217,7 +217,7 @@ export default function GroceryBagPage() {
 
             <Card className="border-border/80 bg-background/85">
               <CardHeader>
-                <CardTitle className="font-display text-3xl">Checkout</CardTitle>
+                <CardTitle className="font-display text-3xl">Build Grocery List</CardTitle>
                 <CardDescription>
                   Generate one grocery list from all recipes in your bag.
                 </CardDescription>
@@ -237,7 +237,7 @@ export default function GroceryBagPage() {
                 {errorMessage ? (
                   <Card className="border-destructive/35 bg-destructive/5">
                     <CardHeader>
-                      <CardTitle className="text-base">Checkout failed</CardTitle>
+                      <CardTitle className="text-base">List generation failed</CardTitle>
                       <CardDescription>{errorMessage}</CardDescription>
                     </CardHeader>
                   </Card>

--- a/apps/web/src/app/bag/page.tsx
+++ b/apps/web/src/app/bag/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ArrowLeft, Loader2, ShoppingBag, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
 import { useGroceryBag } from "@/components/grocery-bag-provider";
@@ -89,6 +89,7 @@ export default function GroceryBagPage() {
   const [generatedList, setGeneratedList] = useState<CreateGroceryListResponse | null>(
     null,
   );
+  const generationRequestIdRef = useRef(0);
 
   const recipeIds = useMemo(() => items.map((item) => item.id), [items]);
   const hasItems = itemCount > 0;
@@ -99,17 +100,29 @@ export default function GroceryBagPage() {
       return;
     }
 
+    const requestId = generationRequestIdRef.current + 1;
+    generationRequestIdRef.current = requestId;
+    const requestRecipeIds = [...recipeIds];
+
     setIsGenerating(true);
     setErrorMessage(null);
 
     try {
-      const response = await createGroceryListClient(recipeIds);
+      const response = await createGroceryListClient(requestRecipeIds);
+      if (generationRequestIdRef.current !== requestId) {
+        return;
+      }
       setGeneratedList(response);
     } catch (error) {
+      if (generationRequestIdRef.current !== requestId) {
+        return;
+      }
       setGeneratedList(null);
       setErrorMessage(getErrorMessage(error, "Failed to generate grocery list."));
     } finally {
-      setIsGenerating(false);
+      if (generationRequestIdRef.current === requestId) {
+        setIsGenerating(false);
+      }
     }
   }
 
@@ -152,6 +165,8 @@ export default function GroceryBagPage() {
                   variant="outline"
                   size="sm"
                   onClick={() => {
+                    generationRequestIdRef.current += 1;
+                    setIsGenerating(false);
                     clearBag();
                     setGeneratedList(null);
                     setErrorMessage(null);
@@ -204,7 +219,11 @@ export default function GroceryBagPage() {
                         variant="outline"
                         size="sm"
                         onClick={() => {
+                          generationRequestIdRef.current += 1;
+                          setIsGenerating(false);
                           removeRecipe(item.id);
+                          setGeneratedList(null);
+                          setErrorMessage(null);
                         }}
                       >
                         Remove

--- a/apps/web/src/app/browse/components/browse-results-grid.tsx
+++ b/apps/web/src/app/browse/components/browse-results-grid.tsx
@@ -1,6 +1,8 @@
 import { ArrowRight, Clock3, Users2 } from "lucide-react";
 
+import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { RecipeRecord, SearchRecipeResult } from "@/lib/forkfolio-types";
@@ -47,93 +49,105 @@ function SearchCard({
   const canOpen = Boolean(recipeId);
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        if (recipeId) {
-          onOpen(recipeId);
-        }
-      }}
-      disabled={!canOpen}
-      className={`block h-full w-full text-left ${canOpen ? "" : "pointer-events-none opacity-60"}`}
-      aria-label={`Open ${title}`}
-    >
-      <Card className="h-full border-border/80 transition hover:-translate-y-0.5 hover:shadow-md">
-        <CardHeader className="gap-3">
-          <CardTitle className="font-display text-2xl tracking-tight">{title}</CardTitle>
+    <Card className={`h-full border-border/80 transition hover:-translate-y-0.5 hover:shadow-md ${canOpen ? "" : "opacity-60"}`}>
+      <CardHeader className="gap-3">
+        <CardTitle className="font-display text-2xl tracking-tight">{title}</CardTitle>
 
-          <CardDescription className="flex min-h-6 flex-wrap items-center gap-2 text-sm">
-            {recipe ? (
-              <>
-                {recipe.total_time ? (
-                  <Badge variant="outline" className="gap-1.5">
-                    <Clock3 className="size-3" />
-                    {recipe.total_time}
-                  </Badge>
-                ) : null}
-                {recipe.servings ? (
-                  <Badge variant="outline" className="gap-1.5">
-                    <Users2 className="size-3" />
-                    {recipe.servings}
-                  </Badge>
-                ) : null}
-                {!recipe.total_time && !recipe.servings ? (
-                  <span className="text-muted-foreground">Metadata available</span>
-                ) : null}
-              </>
-            ) : isDetailsLoading ? (
-              <>
-                <Skeleton className="h-6 w-20 rounded-full bg-muted/85" />
-                <Skeleton className="h-6 w-16 rounded-full bg-muted/85" />
-              </>
-            ) : (
-              <span className="text-muted-foreground">Metadata unavailable</span>
-            )}
-          </CardDescription>
-        </CardHeader>
-
-        <CardContent className="space-y-3">
-          <div className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
-            Preview
-          </div>
-
+        <CardDescription className="flex min-h-6 flex-wrap items-center gap-2 text-sm">
           {recipe ? (
-            ingredients.length ? (
-              <ul className="space-y-1">
-                {ingredients.map((ingredient) => (
-                  <li
-                    key={`${result.id}-${ingredient}`}
-                    className="truncate text-sm text-foreground/85"
-                    title={ingredient}
-                  >
-                    • {ingredient}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                No ingredient preview available. Open the recipe for full details.
-              </p>
-            )
+            <>
+              {recipe.total_time ? (
+                <Badge variant="outline" className="gap-1.5">
+                  <Clock3 className="size-3" />
+                  {recipe.total_time}
+                </Badge>
+              ) : null}
+              {recipe.servings ? (
+                <Badge variant="outline" className="gap-1.5">
+                  <Users2 className="size-3" />
+                  {recipe.servings}
+                </Badge>
+              ) : null}
+              {!recipe.total_time && !recipe.servings ? (
+                <span className="text-muted-foreground">Metadata available</span>
+              ) : null}
+            </>
           ) : isDetailsLoading ? (
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-11/12 bg-muted/85" />
-              <Skeleton className="h-4 w-10/12 bg-muted/85" />
-              <Skeleton className="h-4 w-9/12 bg-muted/85" />
-            </div>
+            <>
+              <Skeleton className="h-6 w-20 rounded-full bg-muted/85" />
+              <Skeleton className="h-6 w-16 rounded-full bg-muted/85" />
+            </>
+          ) : (
+            <span className="text-muted-foreground">Metadata unavailable</span>
+          )}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <div className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+          Preview
+        </div>
+
+        {recipe ? (
+          ingredients.length ? (
+            <ul className="space-y-1">
+              {ingredients.map((ingredient) => (
+                <li
+                  key={`${result.id}-${ingredient}`}
+                  className="truncate text-sm text-foreground/85"
+                  title={ingredient}
+                >
+                  • {ingredient}
+                </li>
+              ))}
+            </ul>
           ) : (
             <p className="text-sm text-muted-foreground">
-              Preview unavailable right now. Open the recipe for full details.
+              No ingredient preview available. Open the recipe for full details.
             </p>
-          )}
-
-          <div className="inline-flex items-center gap-1.5 text-sm font-medium text-primary">
-            Open recipe
-            <ArrowRight className="size-4" />
+          )
+        ) : isDetailsLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-11/12 bg-muted/85" />
+            <Skeleton className="h-4 w-10/12 bg-muted/85" />
+            <Skeleton className="h-4 w-9/12 bg-muted/85" />
           </div>
-        </CardContent>
-      </Card>
-    </button>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Preview unavailable right now. Open the recipe for full details.
+          </p>
+        )}
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled={!canOpen}
+            onClick={() => {
+              if (recipeId) {
+                onOpen(recipeId);
+              }
+            }}
+            aria-label={`Open ${title}`}
+          >
+            Open Recipe
+            <ArrowRight className="size-4" />
+          </Button>
+          {recipe ? (
+            <RecipeBagToggleButton
+              recipe={{
+                id: recipe.id,
+                title: recipe.title,
+                servings: recipe.servings,
+                total_time: recipe.total_time,
+              }}
+              size="sm"
+            />
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/apps/web/src/app/browse/components/recipe-modal.tsx
+++ b/apps/web/src/app/browse/components/recipe-modal.tsx
@@ -1,6 +1,7 @@
 import { Clock3, ExternalLink, Users2, X } from "lucide-react";
 import Link from "next/link";
 
+import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -69,6 +70,17 @@ export function RecipeModal({
           </div>
 
           <div className="flex items-center gap-2">
+            {recipe ? (
+              <RecipeBagToggleButton
+                recipe={{
+                  id: recipe.id,
+                  title: recipe.title,
+                  servings: recipe.servings,
+                  total_time: recipe.total_time,
+                }}
+                size="sm"
+              />
+            ) : null}
             <Button asChild variant="outline" size="sm">
               <Link href={`/recipes/${recipeId}`}>
                 Open Full Page

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Playfair_Display, Source_Sans_3 } from "next/font/google";
+
+import { GroceryBagProvider } from "@/components/grocery-bag-provider";
+
 import "./globals.css";
 
 const sourceSans = Source_Sans_3({
@@ -25,7 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${sourceSans.variable} ${playfair.variable} antialiased`}>
-        {children}
+        <GroceryBagProvider>{children}</GroceryBagProvider>
       </body>
     </html>
   );

--- a/apps/web/src/app/recipes/[recipeId]/page.tsx
+++ b/apps/web/src/app/recipes/[recipeId]/page.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, Clock3, LinkIcon, Users2 } from "lucide-react";
 import { notFound } from "next/navigation";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
 import { RecipeBookMembership } from "@/components/recipe-book-membership";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -161,6 +162,16 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
             <div className="flex flex-wrap gap-x-5 gap-y-1">
               {recipe.created_at ? <span>Created: {recipe.created_at}</span> : null}
               {recipe.updated_at ? <span>Updated: {recipe.updated_at}</span> : null}
+            </div>
+            <div className="mt-5">
+              <RecipeBagToggleButton
+                recipe={{
+                  id: recipe.id,
+                  title: recipe.title,
+                  servings: recipe.servings,
+                  total_time: recipe.total_time,
+                }}
+              />
             </div>
             <Separator className="mt-5" />
           </CardContent>

--- a/apps/web/src/components/forkfolio-header.test.tsx
+++ b/apps/web/src/components/forkfolio-header.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GroceryBagProvider } from "./grocery-bag-provider";
+import { ForkfolioHeader } from "./forkfolio-header";
+
+type LocalStorageMock = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  clear: () => void;
+};
+
+function createLocalStorageMock(): LocalStorageMock {
+  let storage: Record<string, string> = {};
+  return {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+    clear: () => {
+      storage = {};
+    },
+  };
+}
+
+function renderHeader() {
+  return render(
+    <GroceryBagProvider>
+      <ForkfolioHeader />
+    </GroceryBagProvider>,
+  );
+}
+
+describe("ForkfolioHeader", () => {
+  let localStorageMock: LocalStorageMock;
+
+  beforeEach(() => {
+    localStorageMock = createLocalStorageMock();
+    vi.stubGlobal("localStorage", localStorageMock);
+    Object.defineProperty(window, "localStorage", {
+      value: localStorageMock,
+      configurable: true,
+    });
+  });
+
+  it("shows bag count and hover preview for saved recipes", async () => {
+    localStorageMock.setItem(
+      "forkfolio.grocery-bag.v1",
+      JSON.stringify([
+        {
+          id: "recipe-1",
+          title: "Creamy Pasta",
+          servings: "2 servings",
+          total_time: "20 minutes",
+          added_at: "2026-03-10T01:00:00.000Z",
+        },
+        {
+          id: "recipe-2",
+          title: "Tomato Soup",
+          servings: "4 servings",
+          total_time: "35 minutes",
+          added_at: "2026-03-10T01:05:00.000Z",
+        },
+      ]),
+    );
+
+    const user = userEvent.setup();
+    renderHeader();
+
+    const bagLink = await screen.findByRole("link", { name: /Bag/i });
+    await waitFor(() => {
+      expect(bagLink).toHaveTextContent("2");
+    });
+
+    await user.hover(bagLink);
+
+    expect(await screen.findByText("Bag Preview")).toBeInTheDocument();
+    expect(await screen.findByText("Creamy Pasta")).toBeInTheDocument();
+    expect(await screen.findByText("Tomato Soup")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/forkfolio-header.tsx
+++ b/apps/web/src/components/forkfolio-header.tsx
@@ -4,10 +4,17 @@ import Link from "next/link";
 import { BookOpenText, Plus, Search, ShoppingBag, UtensilsCrossed } from "lucide-react";
 
 import { useGroceryBag } from "@/components/grocery-bag-provider";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
 
 export function ForkfolioHeader() {
-  const { itemCount } = useGroceryBag();
+  const { itemCount, items } = useGroceryBag();
+  const previewItems = items.slice(0, 3);
 
   return (
     <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
@@ -41,17 +48,52 @@ export function ForkfolioHeader() {
               Add Recipe
             </Link>
           </Button>
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/bag">
-              <ShoppingBag className="size-4" />
-              Bag
-              {itemCount ? (
-                <span className="inline-flex min-w-6 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-semibold text-primary-foreground">
-                  {itemCount}
-                </span>
-              ) : null}
-            </Link>
-          </Button>
+          <HoverCard openDelay={150}>
+            <HoverCardTrigger asChild>
+              <Link
+                href="/bag"
+                className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+              >
+                <ShoppingBag className="size-4" />
+                Bag
+                {itemCount ? (
+                  <span className="inline-flex min-w-6 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-semibold text-primary-foreground">
+                    {itemCount}
+                  </span>
+                ) : null}
+              </Link>
+            </HoverCardTrigger>
+            <HoverCardContent align="end" className="w-80 space-y-3">
+              <div className="space-y-1">
+                <p className="text-sm font-medium">Bag Preview</p>
+                <p className="text-xs text-muted-foreground">
+                  {itemCount} recipe{itemCount === 1 ? "" : "s"} selected
+                </p>
+              </div>
+
+              {!itemCount ? (
+                <p className="text-sm text-muted-foreground">
+                  Add recipes from browse or detail pages to build your grocery list.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {previewItems.map((item) => (
+                    <div key={item.id} className="rounded-md border border-border/70 px-2.5 py-2">
+                      <p className="truncate text-sm font-medium">{item.title || "Untitled recipe"}</p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {item.total_time || item.servings || "No metadata"}
+                      </p>
+                    </div>
+                  ))}
+                  {itemCount > previewItems.length ? (
+                    <p className="text-xs text-muted-foreground">
+                      +{itemCount - previewItems.length} more in bag
+                    </p>
+                  ) : null}
+                </div>
+              )}
+            </HoverCardContent>
+          </HoverCard>
         </nav>
       </div>
     </header>

--- a/apps/web/src/components/forkfolio-header.tsx
+++ b/apps/web/src/components/forkfolio-header.tsx
@@ -1,9 +1,14 @@
-import Link from "next/link";
-import { BookOpenText, Plus, Search, UtensilsCrossed } from "lucide-react";
+"use client";
 
+import Link from "next/link";
+import { BookOpenText, Plus, Search, ShoppingBag, UtensilsCrossed } from "lucide-react";
+
+import { useGroceryBag } from "@/components/grocery-bag-provider";
 import { Button } from "@/components/ui/button";
 
 export function ForkfolioHeader() {
+  const { itemCount } = useGroceryBag();
+
   return (
     <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
       <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
@@ -34,6 +39,17 @@ export function ForkfolioHeader() {
             <Link href="/recipes/new">
               <Plus className="size-4" />
               Add Recipe
+            </Link>
+          </Button>
+          <Button asChild variant="secondary" size="sm">
+            <Link href="/bag">
+              <ShoppingBag className="size-4" />
+              Bag
+              {itemCount ? (
+                <span className="inline-flex min-w-6 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-semibold text-primary-foreground">
+                  {itemCount}
+                </span>
+              ) : null}
             </Link>
           </Button>
         </nav>

--- a/apps/web/src/components/grocery-bag-provider.tsx
+++ b/apps/web/src/components/grocery-bag-provider.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import type { GroceryBagItem, GroceryBagRecipe } from "@/lib/forkfolio-types";
+
+const GROCERY_BAG_STORAGE_KEY = "forkfolio.grocery-bag.v1";
+
+type GroceryBagContextValue = {
+  items: GroceryBagItem[];
+  itemCount: number;
+  hasRecipe: (recipeId: string) => boolean;
+  addRecipe: (recipe: GroceryBagRecipe) => void;
+  removeRecipe: (recipeId: string) => void;
+  clearBag: () => void;
+};
+
+const DEFAULT_CONTEXT_VALUE: GroceryBagContextValue = {
+  items: [],
+  itemCount: 0,
+  hasRecipe: () => false,
+  addRecipe: () => undefined,
+  removeRecipe: () => undefined,
+  clearBag: () => undefined,
+};
+
+const GroceryBagContext = createContext<GroceryBagContextValue>(DEFAULT_CONTEXT_VALUE);
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function sanitizeStoredItem(value: unknown): GroceryBagItem | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+  if (!id) {
+    return null;
+  }
+
+  const title =
+    typeof candidate.title === "string" && candidate.title.trim()
+      ? candidate.title.trim()
+      : "Untitled recipe";
+  const addedAt =
+    typeof candidate.added_at === "string" && candidate.added_at.trim()
+      ? candidate.added_at
+      : new Date().toISOString();
+
+  return {
+    id,
+    title,
+    servings: normalizeOptionalString(candidate.servings),
+    total_time: normalizeOptionalString(candidate.total_time),
+    added_at: addedAt,
+  };
+}
+
+function dedupeByRecipeId(items: GroceryBagItem[]): GroceryBagItem[] {
+  const byId = new Map<string, GroceryBagItem>();
+  for (const item of items) {
+    byId.set(item.id, item);
+  }
+  return Array.from(byId.values());
+}
+
+function readStoredBag(): GroceryBagItem[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(GROCERY_BAG_STORAGE_KEY);
+    if (!rawValue) {
+      return [];
+    }
+    const parsedValue = JSON.parse(rawValue) as unknown;
+    if (!Array.isArray(parsedValue)) {
+      return [];
+    }
+
+    const sanitizedItems = parsedValue
+      .map((entry) => sanitizeStoredItem(entry))
+      .filter((entry): entry is GroceryBagItem => Boolean(entry));
+
+    return dedupeByRecipeId(sanitizedItems);
+  } catch {
+    return [];
+  }
+}
+
+export function GroceryBagProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<GroceryBagItem[]>([]);
+  const hasLoadedPersistedState = useRef(false);
+
+  useEffect(() => {
+    // Read localStorage after mount so server-rendered HTML stays stable.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setItems(readStoredBag());
+    hasLoadedPersistedState.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!hasLoadedPersistedState.current || typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem(GROCERY_BAG_STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
+
+  const value = useMemo<GroceryBagContextValue>(() => {
+    function hasRecipe(recipeId: string): boolean {
+      const normalizedRecipeId = recipeId.trim();
+      if (!normalizedRecipeId) {
+        return false;
+      }
+      return items.some((item) => item.id === normalizedRecipeId);
+    }
+
+    function addRecipe(recipe: GroceryBagRecipe): void {
+      const normalizedRecipeId = recipe.id.trim();
+      if (!normalizedRecipeId) {
+        return;
+      }
+
+      setItems((prev) => {
+        if (prev.some((item) => item.id === normalizedRecipeId)) {
+          return prev;
+        }
+
+        const normalizedTitle = recipe.title?.trim() || "Untitled recipe";
+        return [
+          ...prev,
+          {
+            id: normalizedRecipeId,
+            title: normalizedTitle,
+            servings: recipe.servings ?? null,
+            total_time: recipe.total_time ?? null,
+            added_at: new Date().toISOString(),
+          },
+        ];
+      });
+    }
+
+    function removeRecipe(recipeId: string): void {
+      const normalizedRecipeId = recipeId.trim();
+      if (!normalizedRecipeId) {
+        return;
+      }
+      setItems((prev) => prev.filter((item) => item.id !== normalizedRecipeId));
+    }
+
+    function clearBag(): void {
+      setItems([]);
+    }
+
+    return {
+      items,
+      itemCount: items.length,
+      hasRecipe,
+      addRecipe,
+      removeRecipe,
+      clearBag,
+    };
+  }, [items]);
+
+  return <GroceryBagContext.Provider value={value}>{children}</GroceryBagContext.Provider>;
+}
+
+export function useGroceryBag(): GroceryBagContextValue {
+  return useContext(GroceryBagContext);
+}

--- a/apps/web/src/components/recipe-bag-toggle-button.tsx
+++ b/apps/web/src/components/recipe-bag-toggle-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Check, ShoppingBag } from "lucide-react";
+import { MouseEvent } from "react";
+
+import { useGroceryBag } from "@/components/grocery-bag-provider";
+import { Button } from "@/components/ui/button";
+import type { GroceryBagRecipe } from "@/lib/forkfolio-types";
+
+type RecipeBagToggleButtonProps = {
+  recipe: GroceryBagRecipe;
+  size?: "sm" | "default" | "lg" | "icon";
+  className?: string;
+};
+
+export function RecipeBagToggleButton({
+  recipe,
+  size = "sm",
+  className,
+}: RecipeBagToggleButtonProps) {
+  const { hasRecipe, addRecipe, removeRecipe } = useGroceryBag();
+  const isInBag = hasRecipe(recipe.id);
+
+  function onClick(event: MouseEvent<HTMLButtonElement>) {
+    // Keep parent card interactions intact when this button sits inside clickable surfaces.
+    event.stopPropagation();
+
+    if (isInBag) {
+      removeRecipe(recipe.id);
+      return;
+    }
+    addRecipe(recipe);
+  }
+
+  return (
+    <Button
+      type="button"
+      variant={isInBag ? "outline" : "secondary"}
+      size={size}
+      className={className}
+      onClick={onClick}
+      aria-pressed={isInBag}
+    >
+      {isInBag ? <Check className="size-4" /> : <ShoppingBag className="size-4" />}
+      {isInBag ? "In Bag" : "Add to Bag"}
+    </Button>
+  );
+}

--- a/apps/web/src/components/ui/hover-card.tsx
+++ b/apps/web/src/components/ui/hover-card.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { HoverCard as HoverCardPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function HoverCard({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  );
+}
+
+function HoverCardContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardContent, HoverCardTrigger };

--- a/apps/web/src/lib/forkfolio-api.ts
+++ b/apps/web/src/lib/forkfolio-api.ts
@@ -3,6 +3,8 @@ import "server-only";
 import type {
   AddRecipeToBookResponse,
   ApiErrorPayload,
+  CreateGroceryListRequest,
+  CreateGroceryListResponse,
   CreateRecipeBookRequest,
   CreateRecipeBookResponse,
   GetRecipeResponse,
@@ -214,6 +216,18 @@ export async function previewRecipeFromUrl(
   payload: PreviewRecipeFromUrlRequest,
 ): Promise<PreviewRecipeFromUrlResponse> {
   return forkfolioFetch<PreviewRecipeFromUrlResponse>("/recipes/preview-from-url", {
+    method: "POST",
+    headers: buildHeaders({
+      "Content-Type": "application/json",
+    }),
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function createGroceryList(
+  payload: CreateGroceryListRequest,
+): Promise<CreateGroceryListResponse> {
+  return forkfolioFetch<CreateGroceryListResponse>("/recipes/grocery-list", {
     method: "POST",
     headers: buildHeaders({
       "Content-Type": "application/json",

--- a/apps/web/src/lib/forkfolio-types.ts
+++ b/apps/web/src/lib/forkfolio-types.ts
@@ -48,6 +48,15 @@ export type RecipeRecord = {
   embeddings?: RecipeEmbeddingRecord[];
 };
 
+export type GroceryBagRecipe = Pick<
+  RecipeRecord,
+  "id" | "title" | "servings" | "total_time"
+>;
+
+export type GroceryBagItem = GroceryBagRecipe & {
+  added_at: string;
+};
+
 export type GetRecipeResponse = {
   recipe: RecipeRecord;
   success?: boolean;
@@ -116,6 +125,17 @@ export type PreviewRecipeFromUrlFailureResponse = {
 export type PreviewRecipeFromUrlResponse =
   | PreviewRecipeFromUrlSuccessResponse
   | PreviewRecipeFromUrlFailureResponse;
+
+export type CreateGroceryListRequest = {
+  recipe_ids: string[];
+};
+
+export type CreateGroceryListResponse = {
+  recipe_ids: string[];
+  ingredients: string[];
+  count: number;
+  success?: boolean;
+};
 
 export type RecipeBookRecord = {
   id: string;


### PR DESCRIPTION
This PR adds a client-side grocery bag and checkout flow in the web app. Users can add/remove recipes from browse result cards, the recipe modal, and recipe detail pages, see a live bag count in the header, and generate an aggregated grocery list on a new `/bag` page. It adds a new Next.js proxy endpoint (`POST /api/recipes/grocery-list`) plus typed grocery-list request/response support in the shared API client and types. It also includes tests for the new grocery-list API route and bag page checkout behavior.
