### PR TITLE
Harden structured LLM parsing for grocery lists

### DIFF
--- a/app/core/prompts.py
+++ b/app/core/prompts.py
@@ -139,6 +139,13 @@ must merge them into one simple grocery list.
 Return ONLY valid JSON in this schema:
 {"ingredients": ["string", "..."]}
 
+Hard output contract:
+- Output must be a single JSON object that starts with "{" and ends with "}".
+- Do not wrap the JSON in markdown or code fences.
+- Do not output explanations, comments, or extra keys.
+- Never output null for "ingredients"; always output a JSON array.
+- If uncertain, still return valid JSON and use {"ingredients": []}.
+
 Rules:
 - Combine duplicate ingredients into a single consolidated grocery item.
 - Preserve coverage: every distinct ingredient concept from input should appear at

--- a/app/services/llm_generation_service.py
+++ b/app/services/llm_generation_service.py
@@ -174,18 +174,56 @@ def make_llm_call_structured_output_generic(
             )
         )
 
-        content = completion.choices[0].message.content
+        if not completion.choices:
+            error_msg = "LLM API returned no choices for structured output."
+            logger.error(error_msg)
+            return None, error_msg
+
+        choice = completion.choices[0]
+        message = choice.message
+        content = message.content
         logger.info(f"Structured output response: {content!r}")
+
+        if content is None:
+            refusal = getattr(message, "refusal", None)
+            finish_reason = getattr(choice, "finish_reason", None)
+            has_tool_calls = bool(getattr(message, "tool_calls", None))
+            error_parts = ["Model returned no JSON content."]
+            if refusal:
+                error_parts.append(f"Refusal: {refusal}")
+            if finish_reason:
+                error_parts.append(f"finish_reason={finish_reason}")
+            if has_tool_calls:
+                error_parts.append("Response contained tool calls instead of content.")
+            error_msg = " ".join(error_parts)
+            logger.error(error_msg)
+            return None, error_msg
+
+        if not isinstance(content, (str, bytes, bytearray)):
+            error_msg = (
+                "Model returned unsupported content type for JSON parsing: "
+                f"{type(content).__name__}"
+            )
+            logger.error(error_msg)
+            return None, error_msg
+
+        content_text = (
+            content
+            if isinstance(content, str)
+            else content.decode("utf-8", errors="replace")
+        )
 
         # Parse the JSON response
 
         try:
-            response_data = json.loads(content)
+            response_data = json.loads(content_text)
             result = model_class.model_validate(response_data)
             llm_structured_cache.set(cache_key, result.model_dump())
             return result, None
         except json.JSONDecodeError as e:
-            error_msg = f"Failed to parse JSON response: {e}. Raw content: {content!r}"
+            error_msg = (
+                f"Failed to parse JSON response: {e}. Raw content: {content_text!r}"
+            )
             logger.error(error_msg)
             return None, error_msg
         except Exception as e:

--- a/app/tests/unit/test_llm_generation_service_structured_output.py
+++ b/app/tests/unit/test_llm_generation_service_structured_output.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from app.core.cache import TTLCache
+from app.services import llm_generation_service
+
+
+class _FakeStructuredCompletions:
+    def __init__(
+        self,
+        *,
+        content,
+        finish_reason: str = "stop",
+        refusal: str | None = None,
+        tool_calls=None,
+    ) -> None:
+        self.calls = 0
+        self._content = content
+        self._finish_reason = finish_reason
+        self._refusal = refusal
+        self._tool_calls = tool_calls
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        message = SimpleNamespace(content=self._content)
+        if self._refusal is not None:
+            message.refusal = self._refusal
+        if self._tool_calls is not None:
+            message.tool_calls = self._tool_calls
+        choice = SimpleNamespace(message=message, finish_reason=self._finish_reason)
+        return SimpleNamespace(choices=[choice])
+
+
+class _StructuredResponseModel(BaseModel):
+    ingredients: list[str]
+
+
+def test_structured_output_handles_missing_content(monkeypatch) -> None:
+    fake_completions = _FakeStructuredCompletions(content=None, refusal="safety")
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=fake_completions))
+    cache = TTLCache[dict](ttl_seconds=60, max_items=10)
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
+
+    suffix = uuid4().hex
+    result, error = llm_generation_service.make_llm_call_structured_output_generic(
+        user_prompt=f"user-prompt-{suffix}",
+        system_prompt=f"system-prompt-{suffix}",
+        model_class=_StructuredResponseModel,
+        schema_name="structured_output_missing_content_test",
+    )
+
+    assert result is None
+    assert error is not None
+    assert "Model returned no JSON content." in error
+    assert "Refusal: safety" in error
+    assert "finish_reason=stop" in error
+    assert fake_completions.calls == 1


### PR DESCRIPTION
This PR improves grocery-list aggregation reliability for structured LLM responses. It strengthens the grocery aggregation system prompt with an explicit JSON-only output contract. It also hardens structured response parsing to handle empty choices, None/non-text content, and emits clearer diagnostics including refusal/finish_reason/tool-call context. Finally, it adds a unit test that covers the missing-content path to prevent regressions.