### PR TITLE
Harden structured-output parsing for long recipes

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -110,6 +110,13 @@ class Settings:
         self.LLM_RETRY_MAX_SECONDS: float = self._cfg.getfloat(
             "llm", "retry_max_seconds", fallback=10.0
         )
+        self.LLM_STRUCTURED_MAX_TOKENS: int = self._cfg.getint(
+            "llm", "structured_max_tokens", fallback=3500
+        )
+        structured_attempts = self._cfg.getint(
+            "llm", "structured_output_max_attempts", fallback=2
+        )
+        self.LLM_STRUCTURED_OUTPUT_MAX_ATTEMPTS: int = max(1, structured_attempts)
 
         # Dedupe
         self.DEDUPE_EMBEDDING_TYPE: str = self._cfg.get(

--- a/app/services/llm_generation_service.py
+++ b/app/services/llm_generation_service.py
@@ -158,78 +158,140 @@ def make_llm_call_structured_output_generic(
             type="json_schema",
             json_schema={"name": schema_name, "schema": schema},
         )
+        max_attempts = settings.LLM_STRUCTURED_OUTPUT_MAX_ATTEMPTS
+        base_max_tokens = max(1, settings.LLM_STRUCTURED_MAX_TOKENS)
+        last_error_msg: Optional[str] = None
 
-        # Call with proper JSON schema format
-        completion = _with_retries(
-            lambda: client.chat.completions.create(
-                model=model_name,
-                messages=[
-                    ChatCompletionSystemMessageParam(
-                        role="system", content=system_prompt
-                    ),
-                    ChatCompletionUserMessageParam(role="user", content=user_prompt),
-                ],
-                response_format=response_format,
-                max_tokens=1000,
+        for attempt in range(1, max_attempts + 1):
+            attempt_max_tokens = base_max_tokens * attempt
+
+            completion = _with_retries(
+                lambda: client.chat.completions.create(
+                    model=model_name,
+                    messages=[
+                        ChatCompletionSystemMessageParam(
+                            role="system", content=system_prompt
+                        ),
+                        ChatCompletionUserMessageParam(
+                            role="user", content=user_prompt
+                        ),
+                    ],
+                    response_format=response_format,
+                    max_tokens=attempt_max_tokens,
+                )
             )
-        )
 
-        if not completion.choices:
-            error_msg = "LLM API returned no choices for structured output."
-            logger.error(error_msg)
-            return None, error_msg
+            if not completion.choices:
+                error_msg = "LLM API returned no choices for structured output."
+                logger.error(error_msg)
+                last_error_msg = error_msg
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Retrying structured output after empty choices "
+                        "(attempt %s/%s).",
+                        attempt + 1,
+                        max_attempts,
+                    )
+                    continue
+                return None, error_msg
 
-        choice = completion.choices[0]
-        message = choice.message
-        content = message.content
-        logger.info(f"Structured output response: {content!r}")
-
-        if content is None:
-            refusal = getattr(message, "refusal", None)
-            finish_reason = getattr(choice, "finish_reason", None)
-            has_tool_calls = bool(getattr(message, "tool_calls", None))
-            error_parts = ["Model returned no JSON content."]
-            if refusal:
-                error_parts.append(f"Refusal: {refusal}")
-            if finish_reason:
-                error_parts.append(f"finish_reason={finish_reason}")
-            if has_tool_calls:
-                error_parts.append("Response contained tool calls instead of content.")
-            error_msg = " ".join(error_parts)
-            logger.error(error_msg)
-            return None, error_msg
-
-        if not isinstance(content, (str, bytes, bytearray)):
-            error_msg = (
-                "Model returned unsupported content type for JSON parsing: "
-                f"{type(content).__name__}"
+            choice = completion.choices[0]
+            message = choice.message
+            content = message.content
+            logger.info(
+                "Structured output response (attempt %s/%s): %r",
+                attempt,
+                max_attempts,
+                content,
             )
-            logger.error(error_msg)
-            return None, error_msg
 
-        content_text = (
-            content
-            if isinstance(content, str)
-            else content.decode("utf-8", errors="replace")
-        )
+            if content is None:
+                refusal = getattr(message, "refusal", None)
+                finish_reason = getattr(choice, "finish_reason", None)
+                has_tool_calls = bool(getattr(message, "tool_calls", None))
+                error_parts = ["Model returned no JSON content."]
+                if refusal:
+                    error_parts.append(f"Refusal: {refusal}")
+                if finish_reason:
+                    error_parts.append(f"finish_reason={finish_reason}")
+                if has_tool_calls:
+                    error_parts.append(
+                        "Response contained tool calls instead of content."
+                    )
+                error_msg = " ".join(error_parts)
+                logger.error(error_msg)
+                last_error_msg = error_msg
+                if refusal:
+                    return None, error_msg
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Retrying structured output after missing content "
+                        "(attempt %s/%s). finish_reason=%s",
+                        attempt + 1,
+                        max_attempts,
+                        finish_reason,
+                    )
+                    continue
+                return None, error_msg
 
-        # Parse the JSON response
+            if not isinstance(content, (str, bytes, bytearray)):
+                error_msg = (
+                    "Model returned unsupported content type for JSON parsing: "
+                    f"{type(content).__name__}"
+                )
+                logger.error(error_msg)
+                last_error_msg = error_msg
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Retrying structured output after unsupported content type "
+                        "(attempt %s/%s).",
+                        attempt + 1,
+                        max_attempts,
+                    )
+                    continue
+                return None, error_msg
 
-        try:
-            response_data = json.loads(content_text)
-            result = model_class.model_validate(response_data)
-            llm_structured_cache.set(cache_key, result.model_dump())
-            return result, None
-        except json.JSONDecodeError as e:
-            error_msg = (
-                f"Failed to parse JSON response: {e}. Raw content: {content_text!r}"
+            content_text = (
+                content
+                if isinstance(content, str)
+                else content.decode("utf-8", errors="replace")
             )
-            logger.error(error_msg)
-            return None, error_msg
-        except Exception as e:
-            error_msg = f"Failed to validate response data: {e}"
-            logger.error(error_msg)
-            return None, error_msg
+
+            try:
+                response_data = json.loads(content_text)
+                result = model_class.model_validate(response_data)
+                llm_structured_cache.set(cache_key, result.model_dump())
+                return result, None
+            except json.JSONDecodeError as e:
+                error_msg = (
+                    f"Failed to parse JSON response: {e}. Raw content: {content_text!r}"
+                )
+                logger.error(error_msg)
+                last_error_msg = error_msg
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Retrying structured output after JSON parse failure "
+                        "(attempt %s/%s).",
+                        attempt + 1,
+                        max_attempts,
+                    )
+                    continue
+                return None, error_msg
+            except Exception as e:
+                error_msg = f"Failed to validate response data: {e}"
+                logger.error(error_msg)
+                last_error_msg = error_msg
+                if attempt < max_attempts:
+                    logger.warning(
+                        "Retrying structured output after validation failure "
+                        "(attempt %s/%s).",
+                        attempt + 1,
+                        max_attempts,
+                    )
+                    continue
+                return None, error_msg
+
+        return None, last_error_msg or "Structured output failed without an error"
 
     except Exception as e:
         error_msg = f"LLM API call failed: {e}"

--- a/app/tests/unit/test_llm_generation_service_structured_output.py
+++ b/app/tests/unit/test_llm_generation_service_structured_output.py
@@ -33,6 +33,32 @@ class _FakeStructuredCompletions:
         return SimpleNamespace(choices=[choice])
 
 
+class _SequenceStructuredCompletions:
+    def __init__(self, responses: list[dict]) -> None:
+        self.calls = 0
+        self.kwargs_history: list[dict] = []
+        self._responses = responses
+
+    def create(self, **kwargs):
+        self.calls += 1
+        self.kwargs_history.append(kwargs)
+        index = min(self.calls - 1, len(self._responses) - 1)
+        response = self._responses[index]
+
+        message = SimpleNamespace(content=response.get("content"))
+        refusal = response.get("refusal")
+        if refusal is not None:
+            message.refusal = refusal
+
+        tool_calls = response.get("tool_calls")
+        if tool_calls is not None:
+            message.tool_calls = tool_calls
+
+        finish_reason = response.get("finish_reason", "stop")
+        choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+        return SimpleNamespace(choices=[choice])
+
+
 class _StructuredResponseModel(BaseModel):
     ingredients: list[str]
 
@@ -62,3 +88,91 @@ def test_structured_output_handles_missing_content(monkeypatch) -> None:
     assert "Refusal: safety" in error
     assert "finish_reason=stop" in error
     assert fake_completions.calls == 1
+
+
+def test_structured_output_retries_truncated_json_then_succeeds(monkeypatch) -> None:
+    fake_completions = _SequenceStructuredCompletions(
+        responses=[
+            {
+                "content": '{"ingredients":["1 tomato"',
+                "finish_reason": "length",
+            },
+            {
+                "content": '{"ingredients":["1 tomato"]}',
+                "finish_reason": "stop",
+            },
+        ]
+    )
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=fake_completions))
+    cache = TTLCache[dict](ttl_seconds=60, max_items=10)
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
+    monkeypatch.setattr(
+        llm_generation_service.settings,
+        "LLM_STRUCTURED_OUTPUT_MAX_ATTEMPTS",
+        2,
+    )
+    monkeypatch.setattr(
+        llm_generation_service.settings, "LLM_STRUCTURED_MAX_TOKENS", 250
+    )
+
+    suffix = uuid4().hex
+    result, error = llm_generation_service.make_llm_call_structured_output_generic(
+        user_prompt=f"user-prompt-{suffix}",
+        system_prompt=f"system-prompt-{suffix}",
+        model_class=_StructuredResponseModel,
+        schema_name="structured_output_retry_success_test",
+    )
+
+    assert error is None
+    assert result is not None
+    assert result.ingredients == ["1 tomato"]
+    assert fake_completions.calls == 2
+    assert [kwargs["max_tokens"] for kwargs in fake_completions.kwargs_history] == [
+        250,
+        500,
+    ]
+
+
+def test_structured_output_returns_error_after_retry_exhaustion(monkeypatch) -> None:
+    fake_completions = _SequenceStructuredCompletions(
+        responses=[
+            {
+                "content": '{"ingredients":["1 tomato"',
+                "finish_reason": "length",
+            },
+        ]
+    )
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=fake_completions))
+    cache = TTLCache[dict](ttl_seconds=60, max_items=10)
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
+    monkeypatch.setattr(
+        llm_generation_service.settings,
+        "LLM_STRUCTURED_OUTPUT_MAX_ATTEMPTS",
+        2,
+    )
+    monkeypatch.setattr(
+        llm_generation_service.settings, "LLM_STRUCTURED_MAX_TOKENS", 250
+    )
+
+    suffix = uuid4().hex
+    result, error = llm_generation_service.make_llm_call_structured_output_generic(
+        user_prompt=f"user-prompt-{suffix}",
+        system_prompt=f"system-prompt-{suffix}",
+        model_class=_StructuredResponseModel,
+        schema_name="structured_output_retry_exhaustion_test",
+    )
+
+    assert result is None
+    assert error is not None
+    assert "Failed to parse JSON response" in error
+    assert fake_completions.calls == 2

--- a/config/app.config.ini
+++ b/config/app.config.ini
@@ -31,6 +31,8 @@ model_name = openai/gpt-oss-20b
 max_retries = 3
 retry_base_seconds = 1.0
 retry_max_seconds = 10.0
+structured_max_tokens = 3500
+structured_output_max_attempts = 2
 
 [embeddings]
 model_name = baai/bge-base-en-v1.5


### PR DESCRIPTION
This updates structured LLM output handling to reduce failures on long recipe payloads. It adds configurable structured-output settings (, ) in app config and settings loading. The structured-output helper now retries empty/malformed/invalid JSON responses with increasing token budgets per attempt while still short-circuiting explicit refusals and preserving cache behavior. It also adds unit tests for missing-content handling, truncated-JSON retry success, and retry exhaustion.