### PR TITLE
Pass source URL through URL recipe import flow

### DIFF
--- a/app/api/schemas/ingest.py
+++ b/app/api/schemas/ingest.py
@@ -19,6 +19,12 @@ class RecipeIngestionRequest(BaseModel):
             )
         },
     )
+    source_url: AnyHttpUrl | None = Field(
+        None,
+        description="Optional source URL where the recipe was sourced from.",
+        alias="sourceUrl",
+        json_schema_extra={"example": "https://example.com/chocolate-chip-cookies"},
+    )
     enforce_deduplication: bool = Field(
         True,
         description=(

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -69,9 +69,12 @@ def process_and_store_recipe(
     Takes raw unstructured recipe text and returns the database ID
     of the stored recipe, or an error if processing fails.
     """
+    source_url = (
+        str(ingestion_request.source_url) if ingestion_request.source_url else None
+    )
     recipe_id, error, created = processing_service.process_raw_recipe(
         raw_input=ingestion_request.raw_input,
-        source_url=None,  # Could extend request model to include source_url if needed
+        source_url=source_url,
         enforce_deduplication=ingestion_request.enforce_deduplication,
         is_test=ingestion_request.is_test,
     )

--- a/app/tests/unit/test_recipe_process_and_store_endpoint.py
+++ b/app/tests/unit/test_recipe_process_and_store_endpoint.py
@@ -1,0 +1,107 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1.endpoints import recipes
+from app.core.config import settings
+from app.core.dependencies import get_recipe_manager, get_recipe_processing_service
+
+PROCESS_AND_STORE_PATH = f"{settings.API_BASE_PATH}/recipes/process-and-store"
+RECIPE_ID = "11111111-1111-1111-1111-111111111111"
+SOURCE_URL = "https://example.com/tomato-pasta"
+
+
+class FakeRecipeProcessingService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def process_raw_recipe(
+        self,
+        raw_input: str,
+        source_url: str | None = None,
+        enforce_deduplication: bool = True,
+        is_test: bool = False,
+    ) -> tuple[str, None, bool]:
+        self.calls.append(
+            {
+                "raw_input": raw_input,
+                "source_url": source_url,
+                "enforce_deduplication": enforce_deduplication,
+                "is_test": is_test,
+            }
+        )
+        return RECIPE_ID, None, True
+
+
+class FakeRecipeManager:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def get_full_recipe(self, recipe_id: str) -> dict:
+        self.calls.append(recipe_id)
+        return {
+            "id": recipe_id,
+            "title": "Tomato Pasta",
+            "servings": "2",
+            "total_time": "20 minutes",
+            "source_url": SOURCE_URL,
+            "created_at": None,
+            "updated_at": None,
+            "ingredients": ["200g spaghetti"],
+            "instructions": ["Boil pasta"],
+            "embeddings": [],
+        }
+
+
+def build_client(
+    processing_service: FakeRecipeProcessingService,
+    recipe_manager: FakeRecipeManager,
+) -> TestClient:
+    app = FastAPI()
+    app.include_router(recipes.router)
+    app.dependency_overrides[get_recipe_processing_service] = lambda: processing_service
+    app.dependency_overrides[get_recipe_manager] = lambda: recipe_manager
+    return TestClient(app)
+
+
+def test_process_and_store_forwards_source_url() -> None:
+    processing_service = FakeRecipeProcessingService()
+    recipe_manager = FakeRecipeManager()
+    client = build_client(processing_service, recipe_manager)
+
+    response = client.post(
+        PROCESS_AND_STORE_PATH,
+        json={
+            "raw_input": "Tomato Pasta recipe with ingredients and instructions.",
+            "source_url": SOURCE_URL,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["recipe_id"] == RECIPE_ID
+    assert processing_service.calls == [
+        {
+            "raw_input": "Tomato Pasta recipe with ingredients and instructions.",
+            "source_url": SOURCE_URL,
+            "enforce_deduplication": True,
+            "is_test": False,
+        }
+    ]
+
+
+def test_process_and_store_accepts_source_url_alias() -> None:
+    processing_service = FakeRecipeProcessingService()
+    recipe_manager = FakeRecipeManager()
+    client = build_client(processing_service, recipe_manager)
+
+    response = client.post(
+        PROCESS_AND_STORE_PATH,
+        json={
+            "raw_input": "Tomato Pasta recipe with ingredients and instructions.",
+            "sourceUrl": SOURCE_URL,
+        },
+    )
+
+    assert response.status_code == 200
+    assert processing_service.calls[0]["source_url"] == SOURCE_URL

--- a/apps/web/src/app/api/recipes/process/route.test.ts
+++ b/apps/web/src/app/api/recipes/process/route.test.ts
@@ -95,7 +95,10 @@ describe("POST /api/recipes/process", () => {
 
     const request = new NextRequest("http://localhost:3000/api/recipes/process", {
       method: "POST",
-      body: JSON.stringify({ raw_input: "  raw recipe text  " }),
+      body: JSON.stringify({
+        raw_input: "  raw recipe text  ",
+        source_url: "  https://example.com/recipe  ",
+      }),
       headers: {
         "Content-Type": "application/json",
       },
@@ -107,9 +110,31 @@ describe("POST /api/recipes/process", () => {
     expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(processRecipeMock).toHaveBeenCalledWith({
       raw_input: "raw recipe text",
+      source_url: "https://example.com/recipe",
       enforce_deduplication: true,
       isTest: false,
     });
+  });
+
+  it("returns 422 when source_url is invalid", async () => {
+    const request = new NextRequest("http://localhost:3000/api/recipes/process", {
+      method: "POST",
+      body: JSON.stringify({
+        raw_input: "valid input content",
+        source_url: "ftp://example.com/recipe",
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(422);
+    expect(await response.json()).toEqual({
+      detail: "source_url must use http or https.",
+    });
+    expect(processRecipeMock).not.toHaveBeenCalled();
   });
 
   it("maps Forkfolio API errors", async () => {

--- a/apps/web/src/app/api/recipes/process/route.ts
+++ b/apps/web/src/app/api/recipes/process/route.ts
@@ -8,6 +8,8 @@ import {
 
 type ProcessRoutePayload = {
   raw_input?: unknown;
+  source_url?: unknown;
+  sourceUrl?: unknown;
   enforce_deduplication?: unknown;
   isTest?: unknown;
   is_test?: unknown;
@@ -26,6 +28,12 @@ type NormalizedPayloadResult =
 function normalizePayload(payload: ProcessRoutePayload): NormalizedPayloadResult {
   const rawInput =
     typeof payload.raw_input === "string" ? payload.raw_input.trim() : "";
+  const rawSourceUrl =
+    typeof payload.source_url === "string"
+      ? payload.source_url.trim()
+      : typeof payload.sourceUrl === "string"
+        ? payload.sourceUrl.trim()
+        : "";
 
   if (!rawInput) {
     return {
@@ -39,6 +47,28 @@ function normalizePayload(payload: ProcessRoutePayload): NormalizedPayloadResult
       detail: `raw_input must be at least ${MIN_RECIPE_INPUT_LENGTH} characters.`,
       status: 422,
     };
+  }
+
+  let normalizedSourceUrl: string | undefined;
+  if (rawSourceUrl) {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(rawSourceUrl);
+    } catch {
+      return {
+        detail: "source_url must be a valid URL.",
+        status: 422,
+      };
+    }
+
+    if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+      return {
+        detail: "source_url must use http or https.",
+        status: 422,
+      };
+    }
+
+    normalizedSourceUrl = parsedUrl.toString();
   }
 
   const isTestValue =
@@ -56,6 +86,7 @@ function normalizePayload(payload: ProcessRoutePayload): NormalizedPayloadResult
           ? payload.enforce_deduplication
           : true,
       isTest: isTestValue,
+      ...(normalizedSourceUrl ? { source_url: normalizedSourceUrl } : {}),
     },
     status: 200,
   };

--- a/apps/web/src/app/recipes/new/page.test.tsx
+++ b/apps/web/src/app/recipes/new/page.test.tsx
@@ -133,6 +133,16 @@ describe("/recipes/new page", () => {
     expect(screen.getByRole("button", { name: /Save Another Recipe/i })).toBeInTheDocument();
     expect(screen.queryByLabelText("Recipe URL")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Raw recipe text")).not.toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/recipes/process");
+    const saveRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    const savePayload = JSON.parse(String(saveRequestInit.body));
+    expect(savePayload).toMatchObject({
+      source_url: "https://example.com/pasta",
+      enforce_deduplication: true,
+      isTest: false,
+    });
   });
 
   it("shows error state when API returns failure", async () => {

--- a/apps/web/src/app/recipes/new/page.tsx
+++ b/apps/web/src/app/recipes/new/page.tsx
@@ -64,7 +64,10 @@ async function readErrorPayload(response: Response): Promise<ErrorPayload | null
   }
 }
 
-async function processRecipeClient(rawInput: string): Promise<ProcessRecipeResponse> {
+async function processRecipeClient(
+  rawInput: string,
+  sourceUrl?: string,
+): Promise<ProcessRecipeResponse> {
   const response = await fetch("/api/recipes/process", {
     method: "POST",
     headers: {
@@ -76,6 +79,7 @@ async function processRecipeClient(rawInput: string): Promise<ProcessRecipeRespo
       raw_input: rawInput,
       enforce_deduplication: true,
       isTest: false,
+      ...(sourceUrl ? { source_url: sourceUrl } : {}),
     }),
   });
 
@@ -195,6 +199,7 @@ function SuccessState({
 export default function NewRecipePage() {
   const [rawInput, setRawInput] = useState("");
   const [sourceUrl, setSourceUrl] = useState("");
+  const [textModeSourceUrl, setTextModeSourceUrl] = useState<string | null>(null);
   const [inputMode, setInputMode] = useState<InputMode>("url");
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isSavingPreview, setIsSavingPreview] = useState(false);
@@ -238,7 +243,10 @@ export default function NewRecipePage() {
     setResult(null);
 
     try {
-      const response = await processRecipeClient(normalizedInput);
+      const response = await processRecipeClient(
+        normalizedInput,
+        textModeSourceUrl ?? undefined,
+      );
       setResult(response);
       if (!response.success) {
         setErrorMessage(response.error || "Recipe processing failed.");
@@ -261,6 +269,7 @@ export default function NewRecipePage() {
     setPreviewErrorMessage(null);
     setErrorMessage(null);
     setPreviewResult(null);
+    setTextModeSourceUrl(null);
 
     try {
       const response = await previewRecipeFromUrlClient(normalizedSourceUrl);
@@ -277,7 +286,7 @@ export default function NewRecipePage() {
     }
   }
 
-  async function savePreviewRecipe(preview: RecipePreviewRecord) {
+  async function savePreviewRecipe(preview: RecipePreviewRecord, sourceUrlForSave: string) {
     const normalizedInput = formatRecipePreviewAsRawInput(preview);
 
     setIsSavingPreview(true);
@@ -285,11 +294,12 @@ export default function NewRecipePage() {
     setResult(null);
 
     try {
-      const response = await processRecipeClient(normalizedInput);
+      const response = await processRecipeClient(normalizedInput, sourceUrlForSave);
       setResult(response);
       if (response.success) {
         setPreviewResult(null);
         setSourceUrl("");
+        setTextModeSourceUrl(null);
       } else {
         setErrorMessage(response.error || "Recipe processing failed.");
       }
@@ -300,9 +310,10 @@ export default function NewRecipePage() {
     }
   }
 
-  function applyPreviewAsText(preview: RecipePreviewRecord) {
+  function applyPreviewAsText(preview: RecipePreviewRecord, sourceUrlForSave: string) {
     setRawInput(formatRecipePreviewAsRawInput(preview));
     setInputMode("text");
+    setTextModeSourceUrl(sourceUrlForSave);
     setPreviewErrorMessage(null);
   }
 
@@ -310,6 +321,7 @@ export default function NewRecipePage() {
     setRawInput("");
     setSourceUrl("");
     setInputMode("url");
+    setTextModeSourceUrl(null);
     setIsPreviewing(false);
     setIsSavingPreview(false);
     setIsSubmitting(false);
@@ -382,7 +394,10 @@ export default function NewRecipePage() {
 
               <Tabs
                 value={inputMode}
-                onValueChange={(value) => setInputMode(value as InputMode)}
+                onValueChange={(value) => {
+                  setInputMode(value as InputMode);
+                  setTextModeSourceUrl(null);
+                }}
                 className="space-y-4"
               >
                 <TabsList className="grid w-full grid-cols-2" variant="default">
@@ -492,7 +507,12 @@ export default function NewRecipePage() {
                               <Button
                                 type="button"
                                 variant="outline"
-                                onClick={() => void savePreviewRecipe(successfulPreview.recipe_preview)}
+                                onClick={() =>
+                                  void savePreviewRecipe(
+                                    successfulPreview.recipe_preview,
+                                    successfulPreview.url,
+                                  )
+                                }
                                 disabled={isSavingPreview}
                               >
                                 {isSavingPreview ? (
@@ -508,7 +528,12 @@ export default function NewRecipePage() {
                                 type="button"
                                 variant="ghost"
                                 disabled={isSavingPreview}
-                                onClick={() => applyPreviewAsText(successfulPreview.recipe_preview)}
+                                onClick={() =>
+                                  applyPreviewAsText(
+                                    successfulPreview.recipe_preview,
+                                    successfulPreview.url,
+                                  )
+                                }
                               >
                                 Edit As Text
                               </Button>

--- a/apps/web/src/lib/forkfolio-types.ts
+++ b/apps/web/src/lib/forkfolio-types.ts
@@ -85,6 +85,8 @@ export type GetRecipeResponse = {
 
 export type ProcessRecipeRequest = {
   raw_input: string;
+  source_url?: string;
+  sourceUrl?: string;
   enforce_deduplication?: boolean;
   isTest?: boolean;
   is_test?: boolean;


### PR DESCRIPTION
This PR wires source_url through the URL-based recipe save flow so imported recipes retain their origin URL. It extends the backend ingestion schema and process endpoint pass-through, and updates the web process proxy to accept, validate, and forward source_url (including sourceUrl alias). It also updates the /recipes/new URL preview save and edit-as-text paths to include the source URL in process requests. Coverage was added for backend endpoint pass-through and frontend proxy/page request payload behavior.