### PR TITLE
Refresh frontend shell and recipe workflow layouts

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,23 @@
+## Design Context
+
+### Users
+ForkFolio is for home cooks and meal planners who collect recipes from websites, notes, and social posts, then need to find and reuse them quickly while cooking or planning meals.
+Primary jobs: capture recipes fast, retrieve recipes by ingredients or intent, organize into books, and generate grocery lists with minimal friction.
+
+### Brand Personality
+Warm, practical, and quietly premium.
+Three-word personality: `inviting`, `organized`, `trustworthy`.
+The interface should feel calm and helpful under time pressure, with confidence over novelty.
+
+### Aesthetic Direction
+Light-first editorial kitchen aesthetic with warm neutrals and terracotta/olive accents.
+Use bold display typography for section identity, balanced by highly readable body type.
+Prefer tactile surfaces, layered backgrounds, and purposeful motion over generic card-heavy dashboards.
+Avoid cold enterprise visuals, neon gradients, and dark-mode-first treatment.
+
+### Design Principles
+1. Prioritize cooking workflows: search, save, organize, and list-building should always be obvious and one action away.
+2. Use expressive hierarchy: strong headlines and concise supporting copy to reduce cognitive load.
+3. Keep interaction density adaptive: rich on desktop, simplified stacking on mobile, no feature loss.
+4. Build consistency through shared shells and tokens, not repetitive component cloning.
+5. Use motion and decoration only to clarify structure and state changes, never as ornament.

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,38 @@
-PYTHON_BIN := $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi)
-RUFF_BIN := $(shell if [ -x .venv/bin/ruff ]; then echo .venv/bin/ruff; else echo ruff; fi)
+VENV_DIR := .venv
+VENV_PYTHON := $(VENV_DIR)/bin/python
+VENV_RUFF := $(VENV_DIR)/bin/ruff
+VENV_DEPS_STAMP := $(VENV_DIR)/.deps-ready
+PYTHON_BIN := $(shell if [ -x $(VENV_PYTHON) ]; then echo $(VENV_PYTHON); else echo python3; fi)
+RUFF_BIN := $(shell if [ -x $(VENV_RUFF) ]; then echo $(VENV_RUFF); else echo ruff; fi)
 
 setup-python:
 	uv python install 3.11
-	@if [ -d .venv ]; then mv .venv .venv_backup_$$(date +%Y%m%d_%H%M%S); fi
-	uv venv --python 3.11 .venv
-	uv pip install --python .venv/bin/python -r requirements.txt
+	@if [ -d $(VENV_DIR) ]; then mv $(VENV_DIR) $(VENV_DIR)_backup_$$(date +%Y%m%d_%H%M%S); fi
+	uv venv --python 3.11 $(VENV_DIR)
+	uv pip install --python $(VENV_PYTHON) -r requirements.txt
+	@touch $(VENV_DEPS_STAMP)
+
+ensure-python:
+	@if [ ! -x $(VENV_PYTHON) ]; then \
+		echo "No local virtual environment found. Bootstrapping with 'make setup-python'..."; \
+		$(MAKE) setup-python; \
+	elif [ ! -f $(VENV_DEPS_STAMP) ] || [ requirements.txt -nt $(VENV_DEPS_STAMP) ]; then \
+		echo "Installing/updating Python dependencies from requirements.txt..."; \
+		uv pip install --python $(VENV_PYTHON) -r requirements.txt && \
+		touch $(VENV_DEPS_STAMP); \
+	fi
 
 sync-requirements:
 	uv pip compile requirements.in -o requirements.txt
 
-run:
-	$(PYTHON_BIN) scripts/run.py --reload
+run: ensure-python
+	$(VENV_PYTHON) scripts/run.py --reload
 
 run-fe:
 	bash scripts/run_fe.sh
 
-start:
-	$(PYTHON_BIN) scripts/run.py
+start: ensure-python
+	$(VENV_PYTHON) scripts/run.py
 
 test:
 	$(PYTHON_BIN) -m pytest -c pytest.ini app/tests/unit/ -q

--- a/apps/web/src/app/bag/page.tsx
+++ b/apps/web/src/app/bag/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, Loader2, ShoppingBag, Trash2 } from "lucide-react";
+import { Loader2, ShoppingBag, Trash2 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
 import { useGroceryBag } from "@/components/grocery-bag-provider";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -127,32 +128,19 @@ export default function GroceryBagPage() {
   }
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link href="/browse">
-            <ArrowLeft className="size-4" />
-            Back to Browse
-          </Link>
-        </Button>
+      <PageMain className="space-y-8 ff-animate-enter">
+        <PageBackLink href="/browse" label="Back to Browse" />
 
-        <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
-          <div className="mx-auto max-w-5xl space-y-6">
-            <div className="space-y-3">
-              <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
-                Grocery Bag
-              </Badge>
-              <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
-                Bag then build list
-              </h1>
-              <p className="text-lg text-muted-foreground">
-                Add recipes as you browse, then generate one combined grocery list.
-              </p>
-            </div>
-
-            <Card className="border-border/80 bg-background/85">
+        <PageHero
+          badge="Grocery Bag"
+          title="Bag then build list"
+          description="Add recipes as you browse, then generate one combined grocery list."
+          contentClassName="max-w-5xl"
+        >
+            <Card className="border-border/80 bg-background/85 shadow-none">
               <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
                 <div>
                   <CardTitle className="font-display text-3xl">Selected Recipes</CardTitle>
@@ -234,7 +222,7 @@ export default function GroceryBagPage() {
               </CardContent>
             </Card>
 
-            <Card className="border-border/80 bg-background/85">
+            <Card className="border-border/80 bg-background/85 shadow-none">
               <CardHeader>
                 <CardTitle className="font-display text-3xl">Build Grocery List</CardTitle>
                 <CardDescription>
@@ -265,7 +253,7 @@ export default function GroceryBagPage() {
             </Card>
 
             {generatedList ? (
-              <Card className="border-primary/30 bg-primary/5">
+              <Card className="border-primary/30 bg-primary/6 shadow-none">
                 <CardHeader>
                   <CardTitle className="font-display text-3xl">Your Grocery List</CardTitle>
                   <CardDescription>
@@ -288,9 +276,8 @@ export default function GroceryBagPage() {
                 </CardContent>
               </Card>
             ) : null}
-          </div>
-        </section>
-      </main>
-    </div>
+        </PageHero>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/books/[bookId]/page.test.tsx
+++ b/apps/web/src/app/books/[bookId]/page.test.tsx
@@ -13,6 +13,7 @@ const { getRecipeBookMock, getRecipeMock, isForkfolioApiErrorMock, notFoundMock 
 
 vi.mock("next/navigation", () => ({
   notFound: notFoundMock,
+  usePathname: () => "/books/book-1",
 }));
 
 vi.mock("@/lib/forkfolio-api", () => ({

--- a/apps/web/src/app/books/[bookId]/page.tsx
+++ b/apps/web/src/app/books/[bookId]/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
-import { ArrowLeft, Clock3, Users2 } from "lucide-react";
+import { Clock3, Users2 } from "lucide-react";
 import { notFound } from "next/navigation";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -101,19 +102,14 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
     recipeIds.length > 0 && availableRecipes.length === 0 && missingRecipesCount > 0;
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link href="/books">
-            <ArrowLeft className="size-4" />
-            Back to Recipe Books
-          </Link>
-        </Button>
+      <PageMain className="space-y-6 ff-animate-enter">
+        <PageBackLink href="/books" label="Back to Recipe Books" />
 
         {loadError || !recipeBook ? (
-          <Card className="border-destructive/35 bg-destructive/5">
+          <Card className="border-destructive/35 bg-destructive/5 shadow-none">
             <CardHeader>
               <CardTitle>Unable to load recipe book</CardTitle>
               <CardDescription>{loadError ?? "Something went wrong."}</CardDescription>
@@ -121,19 +117,14 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
           </Card>
         ) : (
           <>
-            <Card className="mb-5">
-              <CardHeader className="space-y-4">
-                <Badge variant="secondary" className="w-fit rounded-full px-3 py-0.5 text-xs">
-                  Recipe Book
-                </Badge>
-                <CardTitle className="font-display text-5xl leading-tight tracking-tight text-primary">
-                  {recipeBook.name}
-                </CardTitle>
-                <CardDescription>
-                  {recipeBook.description?.trim() || "No description yet."}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
+            <PageHero
+              badge="Recipe Book"
+              title={recipeBook.name}
+              description={recipeBook.description?.trim() || "No description yet."}
+              contentClassName="max-w-5xl"
+            >
+              <Card className="border-border/80 bg-background/82 shadow-none">
+                <CardContent className="space-y-4 pt-6">
                 <div className="flex flex-wrap gap-2">
                   <Badge variant="outline">
                     {recipeBook.recipe_count} recipe{recipeBook.recipe_count === 1 ? "" : "s"}
@@ -147,11 +138,12 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
                 <p className="text-sm text-muted-foreground">
                   Book ID: {recipeBook.id}
                 </p>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            </PageHero>
 
             {missingRecipesCount > 0 && !allRecipesUnavailable ? (
-              <Card className="mb-5 border-border/80 bg-background/80">
+              <Card className="border-border/80 bg-background/80 shadow-none">
                 <CardHeader>
                   <CardTitle className="text-base">Some recipes could not be loaded</CardTitle>
                   <CardDescription>
@@ -163,7 +155,7 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
             ) : null}
 
             {!recipeIds.length ? (
-              <Card>
+              <Card className="shadow-none">
                 <CardHeader>
                   <CardTitle>No recipes in this book yet</CardTitle>
                   <CardDescription>
@@ -177,7 +169,7 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
                 </CardContent>
               </Card>
             ) : allRecipesUnavailable ? (
-              <Card>
+              <Card className="shadow-none">
                 <CardHeader>
                   <CardTitle>Recipes are currently unavailable</CardTitle>
                   <CardDescription>
@@ -196,7 +188,7 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
                 <h2 className="font-display text-3xl tracking-tight">Recipes</h2>
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
                   {availableRecipes.map(({ id, recipe }) => (
-                    <Card key={id} className="border-border/80">
+                    <Card key={id} className="border-border/80 bg-background/80 shadow-none">
                       <CardHeader className="space-y-3">
                         <CardTitle className="font-display text-3xl leading-tight">
                           {recipe.title || "Untitled recipe"}
@@ -232,7 +224,7 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
             )}
           </>
         )}
-      </main>
-    </div>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/books/page.tsx
+++ b/apps/web/src/app/books/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, BookOpenText, Loader2, Plus, RefreshCw } from "lucide-react";
+import { BookOpenText, Loader2, Plus, RefreshCw } from "lucide-react";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
-import { Badge } from "@/components/ui/badge";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -116,7 +116,7 @@ async function createRecipeBookClient(
 
 function StatCard({ label, value }: { label: string; value: string }) {
   return (
-    <Card className="border-border/80 bg-background/80">
+    <Card className="border-border/80 bg-background/82 shadow-none">
       <CardHeader className="space-y-1">
         <CardDescription>{label}</CardDescription>
         <CardTitle className="font-display text-4xl tracking-tight">{value}</CardTitle>
@@ -127,7 +127,7 @@ function StatCard({ label, value }: { label: string; value: string }) {
 
 function RecipeBookCard({ recipeBook }: { recipeBook: RecipeBookRecord }) {
   return (
-    <Card className="border-border/80 transition hover:-translate-y-0.5 hover:shadow-sm">
+    <Card className="border-border/80 bg-background/80 shadow-none transition hover:-translate-y-0.5 hover:shadow-sm">
       <CardHeader>
         <CardTitle className="font-display text-3xl leading-tight">
           {recipeBook.name}
@@ -225,34 +225,20 @@ export default function RecipeBooksPage() {
   }
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link href="/">
-            <ArrowLeft className="size-4" />
-            Back to Home
-          </Link>
-        </Button>
+      <PageMain className="space-y-10 ff-animate-enter">
+        <PageBackLink href="/" label="Back to Home" />
 
-        <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
-          <div className="mx-auto max-w-5xl space-y-8">
-            <div className="space-y-3">
-              <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
-                Recipe Books
-              </Badge>
-              <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
-                Organize recipes into collections
-              </h1>
-              <p className="text-lg text-muted-foreground">
-                Group recipes by cuisine, mood, season, or any style that helps you cook
-                faster.
-              </p>
-            </div>
-
+        <PageHero
+          badge="Recipe Books"
+          title="Organize recipes into collections"
+          description="Group recipes by cuisine, mood, season, or any style that helps you cook faster."
+          contentClassName="max-w-5xl"
+        >
             <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1.25fr_1fr]">
-              <Card className="border-border/80 bg-background/80">
+              <Card className="border-border/80 bg-background/82 shadow-none">
                 <CardHeader>
                   <CardTitle className="font-display text-3xl">Create Recipe Book</CardTitle>
                   <CardDescription>
@@ -268,6 +254,7 @@ export default function RecipeBooksPage() {
                         value={name}
                         onChange={(event) => setName(event.target.value)}
                         placeholder="Weeknight Dinners"
+                        className="border-border/80 bg-background/80"
                       />
                     </div>
 
@@ -278,7 +265,7 @@ export default function RecipeBooksPage() {
                         value={description}
                         onChange={(event) => setDescription(event.target.value)}
                         placeholder="Fast, high-protein meals for weekdays"
-                        className="min-h-24 resize-y"
+                        className="min-h-24 resize-y border-border/80 bg-background/80"
                       />
                     </div>
 
@@ -360,14 +347,13 @@ export default function RecipeBooksPage() {
                 )}
               </div>
             </div>
-          </div>
-        </section>
+        </PageHero>
 
-        <section className="mt-10 space-y-5">
+        <section className="space-y-5 ff-animate-enter-delayed">
           <h2 className="font-display text-3xl tracking-tight">Your Recipe Books</h2>
 
           {!isLoading && !loadError && isBookListTruncated ? (
-            <Card className="border-border/80 bg-background/80">
+            <Card className="border-border/80 bg-background/80 shadow-none">
               <CardHeader>
                 <CardTitle className="text-base">
                   Showing first {RECIPE_BOOKS_LIMIT} recipe books
@@ -416,7 +402,7 @@ export default function RecipeBooksPage() {
             </div>
           ) : null}
         </section>
-      </main>
-    </div>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/browse/components/browse-results-grid.tsx
+++ b/apps/web/src/app/browse/components/browse-results-grid.tsx
@@ -13,7 +13,7 @@ function recipeTitleFromResult(result: SearchRecipeResult): string {
 
 function ResultCardLoading() {
   return (
-    <Card className="h-full border-border/80">
+    <Card className="h-full border-border/80 bg-background/80 shadow-none">
       <CardHeader className="space-y-4">
         <Skeleton className="h-8 w-2/3 rounded-lg bg-muted/85" />
         <div className="flex gap-2">
@@ -50,7 +50,7 @@ function SearchCard({
 
   return (
     <Card
-      className={`relative h-full border-border/80 transition ${
+      className={`relative h-full border-border/80 bg-background/80 shadow-none transition ${
         canOpen ? "hover:-translate-y-0.5 hover:shadow-md" : "opacity-60"
       }`}
     >
@@ -149,8 +149,8 @@ function SearchCard({
             />
           ) : null}
           <div className="inline-flex items-center gap-1.5 text-sm font-medium text-primary">
-          Open recipe
-          <ArrowRight className="size-4" />
+            Open recipe
+            <ArrowRight className="size-4" />
           </div>
         </div>
       </CardContent>
@@ -188,13 +188,13 @@ export function BrowseResultsGrid({
   onCardOpen,
 }: BrowseResultsGridProps) {
   return (
-    <section className="mt-10 space-y-5">
-      <h2 className="font-display text-3xl tracking-tight">
+    <section className="space-y-5 ff-animate-enter-delayed">
+      <h2 className="font-display text-[clamp(1.8rem,3vw,2.4rem)] tracking-tight">
         {queryFromUrl ? `Results for "${queryFromUrl}"` : "Browse Recipes"}
       </h2>
 
       {searchError ? (
-        <Card className="border-destructive/35 bg-destructive/5">
+        <Card className="border-destructive/35 bg-destructive/5 shadow-none">
           <CardHeader>
             <CardTitle>Search Error</CardTitle>
             <CardDescription>{searchError}</CardDescription>
@@ -203,7 +203,7 @@ export function BrowseResultsGrid({
       ) : null}
 
       {showInitialPrompt ? (
-        <Card>
+        <Card className="shadow-none">
           <CardHeader>
             <CardTitle>Start with a query</CardTitle>
             <CardDescription>
@@ -225,7 +225,7 @@ export function BrowseResultsGrid({
       ) : null}
 
       {showNoResults ? (
-        <Card>
+        <Card className="shadow-none">
           <CardHeader>
             <CardTitle>No recipes found</CardTitle>
             <CardDescription>

--- a/apps/web/src/app/browse/components/browse-search-form.tsx
+++ b/apps/web/src/app/browse/components/browse-search-form.tsx
@@ -25,7 +25,7 @@ export function BrowseSearchForm({
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row">
       <div className="relative flex-1">
-        <Search className="pointer-events-none absolute top-1/2 left-3.5 size-5 -translate-y-1/2 text-muted-foreground" />
+        <Search className="pointer-events-none absolute top-1/2 left-3.5 size-5 -translate-y-1/2 text-muted-foreground/80" />
         <Input
           type="search"
           name="q"
@@ -34,13 +34,13 @@ export function BrowseSearchForm({
             onQueryInputChange(event.target.value);
           }}
           placeholder="Search recipes... e.g. 'creamy pasta' or 'quick breakfast'"
-          className="h-14 rounded-2xl border-border/90 bg-background pl-11 text-base"
+          className="h-14 rounded-2xl border-border/85 bg-background/85 pl-11 text-base"
         />
       </div>
       <Button
         type="submit"
         size="lg"
-        className="h-14 rounded-2xl px-8 text-lg"
+        className="h-14 rounded-2xl px-8 text-base sm:text-lg"
         disabled={isSearching}
       >
         Search

--- a/apps/web/src/app/browse/components/recipe-modal.tsx
+++ b/apps/web/src/app/browse/components/recipe-modal.tsx
@@ -38,11 +38,11 @@ export function RecipeModal({
       <DialogContent
         showCloseButton={false}
         aria-describedby={undefined}
-        className="w-full max-w-5xl overflow-hidden border-border/80 bg-background p-0 shadow-xl sm:max-w-5xl"
+        className="w-full max-w-5xl overflow-hidden rounded-2xl border-border/80 bg-background/95 p-0 shadow-2xl sm:max-w-5xl"
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
 
-        <div className="flex items-start justify-between gap-4 border-b border-border/70 px-6 py-5">
+        <div className="flex items-start justify-between gap-4 border-b border-border/70 bg-card/45 px-6 py-5">
           <div className="space-y-2">
             {recipe ? (
               <h3 className="font-display text-4xl leading-tight tracking-tight text-primary sm:text-5xl">
@@ -108,7 +108,7 @@ export function RecipeModal({
 
         <div className="max-h-[75vh] overflow-y-auto px-6 py-5">
           {error ? (
-            <Card className="border-destructive/35 bg-destructive/5">
+            <Card className="border-destructive/35 bg-destructive/5 shadow-none">
               <CardHeader>
                 <CardTitle>Unable to load recipe</CardTitle>
                 <CardDescription>{error}</CardDescription>
@@ -118,7 +118,7 @@ export function RecipeModal({
 
           {!error && isLoading && !recipe ? (
             <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_1.3fr]">
-              <Card>
+              <Card className="shadow-none">
                 <CardHeader>
                   <Skeleton className="h-10 w-40 bg-muted/85" />
                   <Skeleton className="h-5 w-24 bg-muted/85" />
@@ -131,7 +131,7 @@ export function RecipeModal({
                 </CardContent>
               </Card>
 
-              <Card>
+              <Card className="shadow-none">
                 <CardHeader>
                   <Skeleton className="h-10 w-44 bg-muted/85" />
                   <Skeleton className="h-5 w-24 bg-muted/85" />
@@ -148,7 +148,7 @@ export function RecipeModal({
 
           {recipe ? (
             <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_1.3fr]">
-              <Card>
+              <Card className="border-border/80 bg-background/80 shadow-none">
                 <CardHeader>
                   <CardTitle className="font-display text-3xl">Ingredients</CardTitle>
                   <CardDescription>
@@ -167,7 +167,7 @@ export function RecipeModal({
                 </CardContent>
               </Card>
 
-              <Card>
+              <Card className="border-border/80 bg-background/80 shadow-none">
                 <CardHeader>
                   <CardTitle className="font-display text-3xl">Instructions</CardTitle>
                   <CardDescription>

--- a/apps/web/src/app/browse/loading.tsx
+++ b/apps/web/src/app/browse/loading.tsx
@@ -1,4 +1,5 @@
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -25,26 +26,28 @@ function ResultCardSkeleton() {
 
 export default function BrowseLoading() {
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-        <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
-          <div className="mx-auto max-w-4xl space-y-6">
-            <div className="space-y-3">
-              <Skeleton className="h-5 w-28 rounded-full" />
-              <Skeleton className="h-14 w-2/3" />
-              <Skeleton className="h-6 w-4/5" />
-            </div>
-
-            <div className="flex flex-col gap-3 sm:flex-row">
-              <Skeleton className="h-14 flex-1 rounded-2xl" />
-              <Skeleton className="h-14 w-full rounded-2xl sm:w-36" />
-            </div>
+      <PageMain className="space-y-10">
+        <PageHero
+          badge="Browse Recipes"
+          title="Find anything instantly"
+          description="Browse your latest recipes or search by dish, ingredient, or cuisine."
+          contentClassName="max-w-4xl"
+        >
+          <div className="space-y-3">
+            <Skeleton className="h-14 w-2/3" />
+            <Skeleton className="h-6 w-4/5" />
           </div>
-        </section>
 
-        <section className="mt-10 space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Skeleton className="h-14 flex-1 rounded-2xl" />
+            <Skeleton className="h-14 w-full rounded-2xl sm:w-36" />
+          </div>
+        </PageHero>
+
+        <section className="space-y-5">
           <Skeleton className="h-10 w-64" />
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             <ResultCardSkeleton />
@@ -55,7 +58,7 @@ export default function BrowseLoading() {
             <ResultCardSkeleton />
           </div>
         </section>
-      </main>
-    </div>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/browse/page.test.tsx
+++ b/apps/web/src/app/browse/page.test.tsx
@@ -14,6 +14,7 @@ vi.mock("next/navigation", () => ({
     replace: replaceMock,
   }),
   useSearchParams: () => searchParams,
+  usePathname: () => "/browse",
 }));
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/apps/web/src/app/browse/page.tsx
+++ b/apps/web/src/app/browse/page.tsx
@@ -1,11 +1,7 @@
 "use client";
 
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
-
 import { ForkfolioHeader } from "@/components/forkfolio-header";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 
 import { BrowseResultsGrid } from "./components/browse-results-grid";
 import { BrowseSearchForm } from "./components/browse-search-form";
@@ -39,40 +35,26 @@ export default function BrowsePage() {
   } = useBrowseData();
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <div className={hasModal ? "pointer-events-none select-none blur-[3px]" : ""}>
         <ForkfolioHeader />
 
-        <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-          <Button asChild variant="ghost" className="mb-4">
-            <Link href="/">
-              <ArrowLeft className="size-4" />
-              Back to Home
-            </Link>
-          </Button>
+        <PageMain className="space-y-8 ff-animate-enter">
+          <PageBackLink href="/" label="Back to Home" />
 
-          <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
-            <div className="mx-auto max-w-4xl space-y-6">
-              <div className="space-y-2">
-                <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
-                  Browse Recipes
-                </Badge>
-                <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
-                  Find anything instantly
-                </h1>
-                <p className="text-lg text-muted-foreground">
-                  Browse your latest recipes or search by dish, ingredient, or cuisine.
-                </p>
-              </div>
-
+          <PageHero
+            badge="Browse Recipes"
+            title="Find anything instantly"
+            description="Browse your latest recipes or search by dish, ingredient, or cuisine."
+            contentClassName="max-w-4xl"
+          >
               <BrowseSearchForm
                 queryInput={queryInput}
                 isSearching={isSearching}
                 onQueryInputChange={handleQueryInputChange}
                 onSearchSubmit={handleSearchSubmit}
               />
-            </div>
-          </section>
+          </PageHero>
 
           <BrowseResultsGrid
             queryFromUrl={queryFromUrl}
@@ -88,7 +70,7 @@ export default function BrowsePage() {
             onLoadMore={handleLoadMore}
             onCardOpen={openRecipeModal}
           />
-        </main>
+        </PageMain>
       </div>
 
       {hasModal ? (
@@ -100,6 +82,6 @@ export default function BrowsePage() {
           onClose={closeRecipeModal}
         />
       ) : null}
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -124,15 +124,70 @@
   }
   body {
     @apply bg-background text-foreground font-sans;
+    position: relative;
     background-image:
-      radial-gradient(circle at 15% 5%, color-mix(in oklab, var(--primary) 20%, transparent) 0, transparent 32%),
-      radial-gradient(circle at 85% 0%, color-mix(in oklab, var(--accent) 18%, transparent) 0, transparent 26%);
+      radial-gradient(circle at 10% 0%, color-mix(in oklab, var(--primary) 20%, transparent) 0, transparent 36%),
+      radial-gradient(circle at 90% 3%, color-mix(in oklab, var(--accent) 18%, transparent) 0, transparent 30%),
+      linear-gradient(
+        145deg,
+        color-mix(in oklab, var(--background) 95%, var(--primary) 5%) 0%,
+        color-mix(in oklab, var(--background) 97%, var(--accent) 3%) 48%,
+        color-mix(in oklab, var(--background) 92%, var(--secondary) 8%) 100%
+      );
     min-height: 100vh;
+  }
+
+  body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.2;
+    background-image:
+      repeating-linear-gradient(
+        -40deg,
+        color-mix(in oklab, var(--foreground) 8%, transparent) 0,
+        color-mix(in oklab, var(--foreground) 8%, transparent) 1px,
+        transparent 1px,
+        transparent 18px
+      );
   }
 }
 
 @layer utilities {
   .font-display {
     font-family: var(--font-display), "Times New Roman", serif;
+  }
+
+  .ff-animate-enter {
+    animation: ff-enter 540ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .ff-animate-enter-delayed {
+    animation: ff-enter 640ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation-delay: 100ms;
+  }
+
+  .ff-hero-stack > * + * {
+    margin-top: 1.25rem;
+  }
+}
+
+@keyframes ff-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ff-animate-enter,
+  .ff-animate-enter-delayed {
+    animation: none;
   }
 }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -14,6 +14,7 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
   }),
+  usePathname: () => "/",
 }));
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -12,10 +12,12 @@ import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import {
   RECENT_RECIPES_STORAGE_KEY,
   readRecentRecipes,
@@ -254,50 +256,38 @@ export default function HomePage() {
   }, [hasRecentRecipes]);
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 sm:py-12">
-        <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10 sm:py-12">
-          <div className="mx-auto max-w-5xl space-y-8">
-            <div className="space-y-3">
-              <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
-                Home
-              </Badge>
-              <h1 className="font-display text-5xl leading-tight tracking-tight text-foreground sm:text-6xl">
-                {heroTitle}
-              </h1>
-              <p className="max-w-4xl text-lg leading-snug text-muted-foreground sm:text-xl">
-                Capture recipes in seconds, search semantically, and organize everything
-                into books that make cooking faster.
-              </p>
-            </div>
-
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              <Button asChild size="lg" className="h-14 rounded-full px-8 text-lg font-semibold sm:col-span-1">
+      <PageMain className="space-y-10 ff-animate-enter">
+        <PageHero
+          badge={hasRecentRecipes ? "Welcome Back" : "Home"}
+          title={heroTitle}
+          description="Capture recipes in seconds, search semantically, and organize everything into books that make cooking faster."
+          actions={(
+            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-3">
+              <Button asChild size="lg" className="h-12 rounded-full text-base font-semibold sm:h-14 sm:text-lg">
                 <Link href="/recipes/new">
                   <Plus className="size-5" />
                   Add Recipe
                 </Link>
               </Button>
-
               <Button
                 asChild
                 size="lg"
                 variant="secondary"
-                className="h-14 rounded-full px-8 text-lg font-semibold sm:col-span-1"
+                className="h-12 rounded-full border border-border/70 bg-background/72 text-base font-semibold sm:h-14 sm:text-lg"
               >
                 <Link href="/browse">
                   <Search className="size-5" />
                   Browse
                 </Link>
               </Button>
-
               <Button
                 asChild
                 size="lg"
                 variant="secondary"
-                className="h-14 rounded-full px-8 text-lg font-semibold sm:col-span-1"
+                className="h-12 rounded-full border border-border/70 bg-background/72 text-base font-semibold sm:h-14 sm:text-lg"
               >
                 <Link href="/books">
                   <BookOpenText className="size-5" />
@@ -305,81 +295,88 @@ export default function HomePage() {
                 </Link>
               </Button>
             </div>
+          )}
+        >
+          <Card className="border-border/80 bg-background/88 shadow-none">
+            <CardHeader>
+              <CardTitle className="font-display text-3xl tracking-tight">
+                Find recipes instantly
+              </CardTitle>
+              <CardDescription>
+                Start typing to get quick suggestions, or jump to full browse search.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <form
+                className="flex flex-col gap-3 sm:flex-row"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  router.push(buildBrowseHref(searchInput));
+                }}
+              >
+                <Input
+                  type="search"
+                  value={searchInput}
+                  onChange={(event) => setSearchInput(event.target.value)}
+                  placeholder="Search by dish, ingredient, or style"
+                  className="h-11 border-border/80 bg-background/80 text-base"
+                />
+                <Button type="submit" variant="outline" className="h-11">
+                  <Search className="size-4" />
+                  Search
+                </Button>
+              </form>
 
-            <Card className="border-border/80 bg-background/80">
-              <CardHeader>
-                <CardTitle className="font-display text-3xl tracking-tight">
-                  Find recipes instantly
-                </CardTitle>
-                <CardDescription>
-                  Start typing to get quick suggestions, or jump to full browse search.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <form
-                  className="flex flex-col gap-3 sm:flex-row"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    router.push(buildBrowseHref(searchInput));
-                  }}
-                >
-                  <Input
-                    type="search"
-                    value={searchInput}
-                    onChange={(event) => setSearchInput(event.target.value)}
-                    placeholder="Search by dish, ingredient, or style"
-                    className="h-11 text-base"
-                  />
-                  <Button type="submit" variant="outline" className="h-11">
-                    <Search className="size-4" />
-                    Search
+              <div className="flex flex-wrap gap-2">
+                {QUICK_SEARCH_CHIPS.map((chip) => (
+                  <Button key={chip} asChild size="sm" variant="secondary" className="rounded-full">
+                    <Link href={buildBrowseHref(chip)}>{chip}</Link>
                   </Button>
-                </form>
+                ))}
+              </div>
 
-                <div className="flex flex-wrap gap-2">
-                  {QUICK_SEARCH_CHIPS.map((chip) => (
-                    <Button key={chip} asChild size="sm" variant="secondary">
-                      <Link href={buildBrowseHref(chip)}>{chip}</Link>
-                    </Button>
-                  ))}
+              {canShowQuickResults ? (
+                <div className="space-y-2 rounded-xl border border-border/70 bg-background/74 px-4 py-3">
+                  <p className="text-sm font-semibold text-foreground/90">Quick Results</p>
+                  {visibleSearching ? (
+                    <p className="text-sm text-muted-foreground">Searching...</p>
+                  ) : visibleSearchError ? (
+                    <p className="text-sm text-destructive">{visibleSearchError}</p>
+                  ) : visibleSuggestions.length ? (
+                    visibleSuggestions.map((suggestion) => (
+                      <Button
+                        key={suggestion.id}
+                        asChild
+                        variant="ghost"
+                        className="h-9 w-full justify-start rounded-lg"
+                      >
+                        <Link href={`/recipes/${suggestion.id}`}>{suggestion.name}</Link>
+                      </Button>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No quick matches yet.</p>
+                  )}
                 </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Type at least {MIN_SEARCH_LENGTH} characters to show quick matches.
+                </p>
+              )}
+            </CardContent>
+          </Card>
 
-                {canShowQuickResults ? (
-                  <Card className="border-border/70">
-                    <CardHeader className="pb-3">
-                      <CardTitle className="text-base">Quick Results</CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-2">
-                      {visibleSearching ? (
-                        <p className="text-sm text-muted-foreground">Searching...</p>
-                      ) : visibleSearchError ? (
-                        <p className="text-sm text-destructive">{visibleSearchError}</p>
-                      ) : visibleSuggestions.length ? (
-                        visibleSuggestions.map((suggestion) => (
-                          <Button
-                            key={suggestion.id}
-                            asChild
-                            variant="ghost"
-                            className="w-full justify-start"
-                          >
-                            <Link href={`/recipes/${suggestion.id}`}>{suggestion.name}</Link>
-                          </Button>
-                        ))
-                      ) : (
-                        <p className="text-sm text-muted-foreground">
-                          No quick matches yet.
-                        </p>
-                      )}
-                    </CardContent>
-                  </Card>
-                ) : null}
-              </CardContent>
-            </Card>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline" className="rounded-full bg-background/65 px-3 py-1 text-xs">
+              {recentRecipes.length} recent recipe{recentRecipes.length === 1 ? "" : "s"}
+            </Badge>
+            <Badge variant="outline" className="rounded-full bg-background/65 px-3 py-1 text-xs">
+              {recipeBooks.length} book{recipeBooks.length === 1 ? "" : "s"} loaded
+            </Badge>
           </div>
-        </section>
+        </PageHero>
 
-        <section className="mt-10 grid grid-cols-1 gap-5 lg:grid-cols-[1.4fr_1fr]">
-          <Card className="border-border/80 bg-background/80">
+        <section className="grid grid-cols-1 gap-5 ff-animate-enter-delayed lg:grid-cols-[1.4fr_1fr]">
+          <Card className="border-border/80 bg-background/80 shadow-none">
             <CardHeader>
               <CardTitle className="font-display text-3xl tracking-tight">
                 {hasRecentRecipes ? "Continue where you left off" : "No recent recipes yet"}
@@ -394,19 +391,20 @@ export default function HomePage() {
               {hasRecentRecipes ? (
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                   {recentRecipes.map((recipe) => (
-                    <Card key={recipe.id} className="border-border/70">
-                      <CardHeader>
-                        <CardTitle className="text-xl">{recipe.title}</CardTitle>
-                        <CardDescription>
+                    <article
+                      key={recipe.id}
+                      className="space-y-3 rounded-xl border border-border/70 bg-background/74 px-4 py-4"
+                    >
+                      <div className="space-y-1">
+                        <h3 className="line-clamp-2 text-lg font-semibold">{recipe.title}</h3>
+                        <p className="text-sm text-muted-foreground">
                           Viewed {new Date(recipe.viewed_at).toLocaleDateString()}
-                        </CardDescription>
-                      </CardHeader>
-                      <CardContent>
-                        <Button asChild size="sm" variant="outline">
-                          <Link href={`/recipes/${recipe.id}`}>Open Recipe</Link>
-                        </Button>
-                      </CardContent>
-                    </Card>
+                        </p>
+                      </div>
+                      <Button asChild size="sm" variant="outline">
+                        <Link href={`/recipes/${recipe.id}`}>Open Recipe</Link>
+                      </Button>
+                    </article>
                   ))}
                 </div>
               ) : (
@@ -417,7 +415,7 @@ export default function HomePage() {
             </CardContent>
           </Card>
 
-          <Card className="border-border/80 bg-background/80">
+          <Card className="border-border/80 bg-background/80 shadow-none">
             <CardHeader>
               <CardTitle className="font-display text-3xl tracking-tight">
                 Recipe Books Snapshot
@@ -431,14 +429,15 @@ export default function HomePage() {
                 <p className="text-sm text-destructive">{bookSnapshotError}</p>
               ) : recipeBooks.length ? (
                 recipeBooks.map((book) => (
-                  <Card key={book.id} className="border-border/70">
-                    <CardHeader className="space-y-1">
-                      <CardTitle className="text-lg">{book.name}</CardTitle>
-                      <CardDescription>
-                        {book.recipe_count} recipe{book.recipe_count === 1 ? "" : "s"}
-                      </CardDescription>
-                    </CardHeader>
-                  </Card>
+                  <article
+                    key={book.id}
+                    className="space-y-1 rounded-xl border border-border/70 bg-background/74 px-4 py-3"
+                  >
+                    <h3 className="text-lg font-semibold">{book.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {book.recipe_count} recipe{book.recipe_count === 1 ? "" : "s"}
+                    </p>
+                  </article>
                 ))
               ) : (
                 <p className="text-sm text-muted-foreground">No books yet.</p>
@@ -451,11 +450,19 @@ export default function HomePage() {
           </Card>
         </section>
 
-        <section className="mt-10 space-y-5">
-          <h2 className="font-display text-4xl tracking-tight">What You Can Do</h2>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <section className="space-y-5 ff-animate-enter-delayed">
+          <h2 className="font-display text-[clamp(2rem,3.2vw,2.8rem)] tracking-tight">
+            What You Can Do
+          </h2>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             {FEATURE_CARDS.map((feature) => (
-              <Card key={feature.id} className="border-border/80 bg-background/80">
+              <Card
+                key={feature.id}
+                className={cn(
+                  "border-border/80 bg-background/80 shadow-none",
+                  feature.id === "add" && "md:col-span-2 xl:col-span-1",
+                )}
+              >
                 <CardHeader className="space-y-2">
                   <CardTitle className="font-display text-3xl tracking-tight">
                     {feature.title}
@@ -476,7 +483,7 @@ export default function HomePage() {
             ))}
           </div>
         </section>
-      </main>
-    </div>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/recipes/[recipeId]/not-found.tsx
+++ b/apps/web/src/app/recipes/[recipeId]/not-found.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { ArrowLeft, Plus, Search, TriangleAlert } from "lucide-react";
+import { Plus, Search, TriangleAlert } from "lucide-react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,46 +15,48 @@ import {
 
 export default function RecipeNotFoundPage() {
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-3xl px-4 py-10 sm:px-6">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link href="/browse">
-            <ArrowLeft className="size-4" />
-            Back to Browse
-          </Link>
-        </Button>
+      <PageMain className="max-w-3xl space-y-6 ff-animate-enter">
+        <PageBackLink href="/browse" label="Back to Browse" />
 
-        <Card className="border-border/80 bg-background/80">
-          <CardHeader className="space-y-4">
-            <Badge variant="secondary" className="w-fit rounded-full px-3 py-0.5 text-xs">
-              <TriangleAlert className="size-3.5" />
-              Recipe Not Found
-            </Badge>
-            <CardTitle className="font-display text-4xl leading-tight tracking-tight text-primary">
-              This recipe no longer exists.
-            </CardTitle>
-            <CardDescription className="text-base">
-              It may have been deleted, moved, or the link may be incorrect.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-3 sm:flex-row">
-            <Button asChild className="sm:flex-1">
-              <Link href="/browse">
-                <Search className="size-4" />
-                Browse Recipes
-              </Link>
-            </Button>
-            <Button asChild variant="outline" className="sm:flex-1">
-              <Link href="/recipes/new">
-                <Plus className="size-4" />
-                Add Recipe
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </main>
-    </div>
+        <PageHero
+          badge="Recipe Not Found"
+          title="This recipe no longer exists."
+          description="It may have been deleted, moved, or the link may be incorrect."
+          contentClassName="max-w-3xl"
+        >
+          <Card className="border-border/80 bg-background/82 shadow-none">
+            <CardHeader className="space-y-3">
+              <Badge variant="secondary" className="w-fit rounded-full px-3 py-0.5 text-xs">
+                <TriangleAlert className="size-3.5" />
+                Missing Recipe Link
+              </Badge>
+              <CardTitle className="font-display text-3xl tracking-tight">
+                Try another path
+              </CardTitle>
+              <CardDescription>
+                Browse your saved recipes or import a new one from text or URL.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3 sm:flex-row">
+              <Button asChild className="sm:flex-1">
+                <Link href="/browse">
+                  <Search className="size-4" />
+                  Browse Recipes
+                </Link>
+              </Button>
+              <Button asChild variant="outline" className="sm:flex-1">
+                <Link href="/recipes/new">
+                  <Plus className="size-4" />
+                  Add Recipe
+                </Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </PageHero>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/recipes/[recipeId]/page.tsx
+++ b/apps/web/src/app/recipes/[recipeId]/page.tsx
@@ -1,14 +1,13 @@
-import Link from "next/link";
-import { ArrowLeft, Clock3, LinkIcon, Users2 } from "lucide-react";
+import { Clock3, LinkIcon, Users2 } from "lucide-react";
 import { notFound } from "next/navigation";
 
 import { DeleteRecipeButton } from "@/components/delete-recipe-button";
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
 import { RecipeBookMembership } from "@/components/recipe-book-membership";
 import { TrackRecipeHistory } from "@/components/track-recipe-history";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -55,7 +54,7 @@ function MetadataBadges({ recipe }: { recipe: RecipeRecord }) {
 function RecipeBody({ recipe }: { recipe: RecipeRecord }) {
   return (
     <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_1.3fr]">
-      <Card>
+      <Card className="border-border/80 bg-background/80 shadow-none">
         <CardHeader>
           <CardTitle className="font-display text-3xl">Ingredients</CardTitle>
           <CardDescription>
@@ -74,7 +73,7 @@ function RecipeBody({ recipe }: { recipe: RecipeRecord }) {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className="border-border/80 bg-background/80 shadow-none">
         <CardHeader>
           <CardTitle className="font-display text-3xl">Instructions</CardTitle>
           <CardDescription>
@@ -119,17 +118,12 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
 
   if (!recipe) {
     return (
-      <div className="min-h-screen">
+      <PageShell>
         <ForkfolioHeader />
-        <main className="mx-auto w-full max-w-3xl px-4 py-10 sm:px-6">
-          <Button asChild variant="ghost" className="mb-4">
-            <Link href="/browse">
-              <ArrowLeft className="size-4" />
-              Back to Search
-            </Link>
-          </Button>
+        <PageMain className="max-w-3xl space-y-5 ff-animate-enter">
+          <PageBackLink href="/browse" label="Back to Search" />
 
-          <Card className="border-destructive/35 bg-destructive/5">
+          <Card className="border-destructive/35 bg-destructive/5 shadow-none">
             <CardHeader>
               <CardTitle>Unable to load recipe</CardTitle>
               <CardDescription>
@@ -137,64 +131,61 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
               </CardDescription>
             </CardHeader>
           </Card>
-        </main>
-      </div>
+        </PageMain>
+      </PageShell>
     );
   }
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <TrackRecipeHistory
         recipeId={recipe.id}
         recipeTitle={recipe.title || "Untitled recipe"}
       />
       <ForkfolioHeader />
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link href="/browse">
-            <ArrowLeft className="size-4" />
-            Back to Search
-          </Link>
-        </Button>
+      <PageMain className="space-y-6 ff-animate-enter">
+        <PageBackLink href="/browse" label="Back to Search" />
 
-        <Card className="mb-5">
-          <CardHeader className="space-y-4">
-            <CardTitle className="font-display text-5xl leading-tight tracking-tight text-primary">
-              {recipe.title || "Untitled recipe"}
-            </CardTitle>
-            <MetadataBadges recipe={recipe} />
-          </CardHeader>
-          <CardContent className="text-sm text-muted-foreground">
-            <div className="flex flex-wrap gap-x-5 gap-y-1">
-              {recipe.created_at ? <span>Created: {recipe.created_at}</span> : null}
-              {recipe.updated_at ? <span>Updated: {recipe.updated_at}</span> : null}
-            </div>
-            <div className="mt-5">
-              <RecipeBagToggleButton
-                recipe={{
-                  id: recipe.id,
-                  title: recipe.title,
-                  servings: recipe.servings,
-                  total_time: recipe.total_time,
-                }}
-              />
-            </div>
-            <Separator className="mt-5" />
-            <div className="mt-5">
-              <DeleteRecipeButton
-                recipeId={recipe.id}
-                recipeTitle={recipe.title || "Untitled recipe"}
-              />
-            </div>
-          </CardContent>
-        </Card>
+        <PageHero
+          badge="Recipe"
+          title={recipe.title || "Untitled recipe"}
+          contentClassName="max-w-5xl"
+        >
+          <MetadataBadges recipe={recipe} />
 
-        <section className="mb-5">
+          <Card className="border-border/80 bg-background/82 shadow-none">
+            <CardContent className="space-y-5 pt-6 text-sm text-muted-foreground">
+              <div className="flex flex-wrap gap-x-5 gap-y-1">
+                {recipe.created_at ? <span>Created: {recipe.created_at}</span> : null}
+                {recipe.updated_at ? <span>Updated: {recipe.updated_at}</span> : null}
+              </div>
+              <div>
+                <RecipeBagToggleButton
+                  recipe={{
+                    id: recipe.id,
+                    title: recipe.title,
+                    servings: recipe.servings,
+                    total_time: recipe.total_time,
+                  }}
+                />
+              </div>
+              <Separator />
+              <div>
+                <DeleteRecipeButton
+                  recipeId={recipe.id}
+                  recipeTitle={recipe.title || "Untitled recipe"}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </PageHero>
+
+        <section>
           <RecipeBookMembership recipeId={recipe.id} />
         </section>
 
         <RecipeBody recipe={recipe} />
-      </main>
-    </div>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/app/recipes/new/page.tsx
+++ b/apps/web/src/app/recipes/new/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, ArrowRight, Loader2, Sparkles } from "lucide-react";
+import { ArrowRight, Loader2, Sparkles } from "lucide-react";
 import { FormEvent, useMemo, useState } from "react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
+import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -347,51 +348,28 @@ export default function NewRecipePage() {
     : 0;
 
   return (
-    <div className="min-h-screen">
+    <PageShell>
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link href="/">
-            <ArrowLeft className="size-4" />
-            Back to Home
-          </Link>
-        </Button>
+      <PageMain className="space-y-8 ff-animate-enter">
+        <PageBackLink href="/" label="Back to Home" />
 
         {successfulResult ? (
-          <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
-            <div className="mx-auto max-w-4xl space-y-6">
-              <div className="space-y-3">
-                <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
-                  Recipe Saved
-                </Badge>
-                <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
-                  Recipe saved successfully
-                </h1>
-                <p className="text-lg text-muted-foreground">
-                  Open the saved recipe, browse your collection, or start another import.
-                </p>
-              </div>
-
-              <SuccessState result={successfulResult} onStartOver={resetComposer} />
-            </div>
-          </section>
+          <PageHero
+            badge="Recipe Saved"
+            title="Recipe saved successfully"
+            description="Open the saved recipe, browse your collection, or start another import."
+            contentClassName="max-w-4xl"
+          >
+            <SuccessState result={successfulResult} onStartOver={resetComposer} />
+          </PageHero>
         ) : (
-          <section className="rounded-[2rem] border border-border/70 bg-card/35 px-6 py-10 sm:px-10">
-            <div className="mx-auto max-w-4xl space-y-8">
-              <div className="space-y-3">
-                <Badge variant="secondary" className="rounded-full px-3 py-0.5 text-xs">
-                  Add Recipe
-                </Badge>
-                <h1 className="font-display text-5xl tracking-tight sm:text-6xl">
-                  Turn raw text into a saved recipe
-                </h1>
-                <p className="text-lg text-muted-foreground">
-                  Import from a URL or paste plain text. Use one path at a time for a
-                  cleaner save flow.
-                </p>
-              </div>
-
+          <PageHero
+            badge="Add Recipe"
+            title="Turn raw text into a saved recipe"
+            description="Import from a URL or paste plain text. Use one path at a time for a cleaner save flow."
+            contentClassName="max-w-4xl"
+          >
               <Tabs
                 value={inputMode}
                 onValueChange={(value) => {
@@ -406,7 +384,7 @@ export default function NewRecipePage() {
                 </TabsList>
 
                 <TabsContent value="url">
-                  <Card className="border-border/80 bg-background/80">
+                  <Card className="border-border/80 bg-background/82 shadow-none">
                     <CardHeader className="space-y-2">
                       <CardTitle className="font-display text-3xl">
                         Import From URL
@@ -427,6 +405,7 @@ export default function NewRecipePage() {
                             value={sourceUrl}
                             onChange={(event) => setSourceUrl(event.target.value)}
                             placeholder="https://example.com/chocolate-chip-cookies"
+                            className="border-border/80 bg-background/80"
                           />
                           <p className="text-sm text-muted-foreground">
                             Preview alone does not insert into your database until you save.
@@ -546,7 +525,7 @@ export default function NewRecipePage() {
                 </TabsContent>
 
                 <TabsContent value="text">
-                  <Card className="border-border/80 bg-background/80">
+                  <Card className="border-border/80 bg-background/82 shadow-none">
                     <CardHeader className="space-y-2">
                       <CardTitle className="font-display text-3xl">Recipe Input</CardTitle>
                       <CardDescription>
@@ -565,7 +544,7 @@ export default function NewRecipePage() {
                             placeholder={
                               "Chocolate Chip Cookies\n\nIngredients:\n- 2 cups flour\n- 1 cup butter\n\nInstructions:\n1. Mix ingredients\n2. Bake at 350F"
                             }
-                            className="min-h-56 resize-y"
+                            className="min-h-56 resize-y border-border/80 bg-background/80"
                           />
                           <p className="text-sm text-muted-foreground">
                             {trimmedLength} characters
@@ -593,19 +572,18 @@ export default function NewRecipePage() {
                   </Card>
                 </TabsContent>
               </Tabs>
-            </div>
-          </section>
+          </PageHero>
         )}
 
         {errorMessage ? (
-          <Card className="mt-6 border-destructive/35 bg-destructive/5">
+          <Card className="border-destructive/35 bg-destructive/5 shadow-none">
             <CardHeader>
               <CardTitle>Unable to process recipe</CardTitle>
               <CardDescription>{errorMessage}</CardDescription>
             </CardHeader>
           </Card>
         ) : null}
-      </main>
-    </div>
+      </PageMain>
+    </PageShell>
   );
 }

--- a/apps/web/src/components/delete-recipe-button.test.tsx
+++ b/apps/web/src/components/delete-recipe-button.test.tsx
@@ -14,6 +14,7 @@ vi.mock("next/navigation", () => ({
     push: pushMock,
     refresh: refreshMock,
   }),
+  usePathname: () => "/recipes/recipe-1",
 }));
 
 function jsonResponse(body: unknown, status = 200): Response {

--- a/apps/web/src/components/forkfolio-header.tsx
+++ b/apps/web/src/components/forkfolio-header.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { BookOpenText, Plus, Search, ShoppingBag, UtensilsCrossed } from "lucide-react";
+import { usePathname } from "next/navigation";
 
 import { useGroceryBag } from "@/components/grocery-bag-provider";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -12,58 +13,104 @@ import {
 } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
 
+const NAV_ITEMS = [
+  {
+    href: "/browse",
+    label: "Browse",
+    icon: Search,
+  },
+  {
+    href: "/books",
+    label: "Books",
+    icon: BookOpenText,
+  },
+  {
+    href: "/recipes/new",
+    label: "Add Recipe",
+    icon: Plus,
+  },
+] as const;
+
+function isRouteActive(pathname: string, href: string): boolean {
+  if (pathname === href) {
+    return true;
+  }
+  if (href === "/") {
+    return pathname === "/";
+  }
+  return pathname.startsWith(`${href}/`);
+}
+
 export function ForkfolioHeader() {
+  const pathname = usePathname() ?? "/";
   const { itemCount, items } = useGroceryBag();
   const previewItems = items.slice(0, 3);
+  const bagActive = isRouteActive(pathname, "/bag");
 
   return (
-    <header className="sticky top-0 z-20 border-b border-border/70 bg-background/95 backdrop-blur">
-      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+    <header className="sticky top-0 z-30 border-b border-border/70 bg-background/90 backdrop-blur-xl">
+      <div className="mx-auto w-full max-w-6xl px-4 py-3 sm:px-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
         <Link
           href="/"
-          className="inline-flex items-center gap-2 text-foreground transition-colors hover:text-primary"
+          className="inline-flex items-center gap-2.5 text-foreground transition-colors hover:text-primary"
         >
-          <UtensilsCrossed className="size-6 text-primary" />
-          <span className="font-display text-3xl font-semibold tracking-tight sm:text-4xl">
+          <span className="inline-flex size-9 items-center justify-center rounded-full bg-primary/15 text-primary">
+            <UtensilsCrossed className="size-5" />
+          </span>
+          <span className="font-display text-2xl font-semibold tracking-tight sm:text-3xl">
             ForkFolio
           </span>
         </Link>
 
-        <nav className="flex items-center gap-2">
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/browse">
-              <Search className="size-4" />
-              Browse
-            </Link>
-          </Button>
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/books">
-              <BookOpenText className="size-4" />
-              Books
-            </Link>
-          </Button>
-          <Button asChild variant="secondary" size="sm">
-            <Link href="/recipes/new">
-              <Plus className="size-4" />
-              Add Recipe
-            </Link>
-          </Button>
+        <nav className="grid w-full grid-cols-2 gap-2 sm:w-auto sm:auto-cols-max sm:grid-flow-col sm:grid-cols-none sm:gap-1.5">
+          {NAV_ITEMS.map((item) => {
+            const active = isRouteActive(pathname, item.href);
+
+            return (
+              <Button
+                key={item.href}
+                asChild
+                variant={active ? "default" : "secondary"}
+                size="sm"
+                className="h-9 rounded-full px-3.5"
+              >
+                <Link href={item.href} aria-current={active ? "page" : undefined}>
+                  <item.icon className="size-4" />
+                  {item.label}
+                </Link>
+              </Button>
+            );
+          })}
+
           <HoverCard openDelay={150}>
             <HoverCardTrigger asChild>
               <Link
                 href="/bag"
-                className={cn(buttonVariants({ variant: "secondary", size: "sm" }))}
+                aria-current={bagActive ? "page" : undefined}
+                className={cn(
+                  buttonVariants({ variant: bagActive ? "default" : "secondary", size: "sm" }),
+                  "h-9 rounded-full px-3.5",
+                )}
               >
                 <ShoppingBag className="size-4" />
                 Bag
                 {itemCount ? (
-                  <span className="inline-flex min-w-6 items-center justify-center rounded-full bg-primary px-1.5 text-xs font-semibold text-primary-foreground">
+                  <span
+                    className={cn(
+                      "inline-flex min-w-6 items-center justify-center rounded-full px-1.5 text-xs font-semibold",
+                      bagActive ? "bg-background text-foreground" : "bg-primary text-primary-foreground",
+                    )}
+                  >
                     {itemCount}
                   </span>
                 ) : null}
               </Link>
             </HoverCardTrigger>
-            <HoverCardContent align="end" className="w-80 space-y-3">
+            <HoverCardContent
+              align="end"
+              className="w-[min(20rem,calc(100vw-2rem))] space-y-3 rounded-xl border-border/80 bg-background/95"
+            >
               <div className="space-y-1">
                 <p className="text-sm font-medium">Bag Preview</p>
                 <p className="text-xs text-muted-foreground">
@@ -78,7 +125,10 @@ export function ForkfolioHeader() {
               ) : (
                 <div className="space-y-2">
                   {previewItems.map((item) => (
-                    <div key={item.id} className="rounded-md border border-border/70 px-2.5 py-2">
+                    <div
+                      key={item.id}
+                      className="rounded-lg border border-border/70 bg-card/60 px-2.5 py-2"
+                    >
                       <p className="truncate text-sm font-medium">{item.title || "Untitled recipe"}</p>
                       <p className="truncate text-xs text-muted-foreground">
                         {item.total_time || item.servings || "No metadata"}
@@ -95,6 +145,7 @@ export function ForkfolioHeader() {
             </HoverCardContent>
           </HoverCard>
         </nav>
+        </div>
       </div>
     </header>
   );

--- a/apps/web/src/components/page-shell.tsx
+++ b/apps/web/src/components/page-shell.tsx
@@ -1,0 +1,109 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type PageShellProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function PageShell({ children, className }: PageShellProps) {
+  return <div className={cn("relative isolate min-h-screen overflow-x-hidden pb-10", className)}>{children}</div>;
+}
+
+type PageMainProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function PageMain({ children, className }: PageMainProps) {
+  return (
+    <main className={cn("mx-auto w-full max-w-6xl px-4 pt-8 sm:px-6 sm:pt-10", className)}>
+      {children}
+    </main>
+  );
+}
+
+type PageBackLinkProps = {
+  href: string;
+  label: string;
+  className?: string;
+};
+
+export function PageBackLink({ href, label, className }: PageBackLinkProps) {
+  return (
+    <Button
+      asChild
+      variant="ghost"
+      size="sm"
+      className={cn(
+        "mb-5 h-9 rounded-full px-3.5 text-foreground/85 hover:text-foreground",
+        className,
+      )}
+    >
+      <Link href={href}>
+        <ArrowLeft className="size-4" />
+        {label}
+      </Link>
+    </Button>
+  );
+}
+
+type PageHeroProps = {
+  badge: string;
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+};
+
+export function PageHero({
+  badge,
+  title,
+  description,
+  actions,
+  children,
+  className,
+  contentClassName,
+}: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        "relative overflow-hidden rounded-[2rem] border border-border/70 bg-card/35 px-6 py-8 shadow-[0_24px_70px_-36px_color-mix(in_oklab,var(--primary)_55%,transparent)] sm:px-10 sm:py-10",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute -top-12 right-8 h-56 w-56 rounded-full bg-[radial-gradient(circle,color-mix(in_oklab,var(--primary)_22%,transparent)_0%,transparent_70%)]" />
+      <div className="pointer-events-none absolute -bottom-16 -left-10 h-64 w-64 rounded-full bg-[radial-gradient(circle,color-mix(in_oklab,var(--accent)_22%,transparent)_0%,transparent_72%)]" />
+
+      <div className={cn("relative z-10 mx-auto max-w-5xl space-y-8", contentClassName)}>
+        <div className="space-y-3">
+          <Badge
+            variant="secondary"
+            className="rounded-full border border-border/60 bg-background/70 px-3 py-0.5 text-[0.68rem] font-semibold tracking-[0.08em] uppercase"
+          >
+            {badge}
+          </Badge>
+          <h1 className="font-display text-[clamp(2.3rem,6vw,4.2rem)] leading-[0.95] tracking-tight text-foreground">
+            {title}
+          </h1>
+          {description ? (
+            <p className="max-w-4xl text-base leading-relaxed text-muted-foreground sm:text-lg">
+              {description}
+            </p>
+          ) : null}
+        </div>
+
+        {actions ? <div className="flex flex-wrap gap-3">{actions}</div> : null}
+
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -2,6 +2,15 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
 
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    usePathname: () => "/",
+  };
+});
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();


### PR DESCRIPTION
Adds a reusable page layout system (`PageShell`, `PageMain`, `PageHero`, and `PageBackLink`) and migrates the main frontend flows (home, browse, books, bag, recipe detail/not-found, and new recipe) to it.
The visual refresh updates global tokens, background treatment, and motion utilities in `globals.css`, and applies consistent shadcn-based card/input styling across these pages.
Header navigation now includes active-route state and improved bag preview behavior, and route-aware tests were updated with `usePathname` mocks (plus shared Vitest setup mocking).
Backend developer ergonomics are improved by adding `ensure-python` in the Makefile so `make run` and `make start` auto-bootstrap or refresh `.venv` dependencies, and this branch also adds `.impeccable.md` design context.
Local checks run and passing: `npm --prefix apps/web run lint` and `npm --prefix apps/web run test`.
