### PR TITLE
Text-first browse search with optional related results

### DIFF
--- a/apps/web/src/app/browse/browse-api.ts
+++ b/apps/web/src/app/browse/browse-api.ts
@@ -6,6 +6,7 @@ import type {
 
 const SEARCH_LIMIT = 12;
 export const MIN_QUERY_LENGTH = 2;
+export const MIN_TEXT_MATCH_QUERY_LENGTH = 3;
 
 type ErrorPayload = {
   detail?: string;
@@ -71,6 +72,14 @@ export async function searchRecipesClient(
 ): Promise<SearchRecipesResponse> {
   const params = new URLSearchParams({ query, limit: String(limit) });
   return browserFetch<SearchRecipesResponse>(`/api/search?${params.toString()}`);
+}
+
+export async function searchRecipesByNameClient(
+  query: string,
+  limit = SEARCH_LIMIT,
+): Promise<SearchRecipesResponse> {
+  const params = new URLSearchParams({ query, limit: String(limit) });
+  return browserFetch<SearchRecipesResponse>(`/api/search/names?${params.toString()}`);
 }
 
 export async function listRecipesClient(

--- a/apps/web/src/app/browse/components/browse-results-grid.tsx
+++ b/apps/web/src/app/browse/components/browse-results-grid.tsx
@@ -5,9 +5,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { RecipeRecord, SearchRecipeResult } from "@/lib/forkfolio-types";
+import type { RecipeRecord } from "@/lib/forkfolio-types";
 
-function recipeTitleFromResult(result: SearchRecipeResult): string {
+import type { BrowseSearchResult } from "../use-browse-data";
+
+function recipeTitleFromResult(result: BrowseSearchResult): string {
   return result.name?.trim() || "Untitled recipe";
 }
 
@@ -38,7 +40,7 @@ function SearchCard({
   isDetailsLoading,
   onOpen,
 }: {
-  result: SearchRecipeResult;
+  result: BrowseSearchResult;
   recipe?: RecipeRecord;
   isDetailsLoading: boolean;
   onOpen: (recipeId: string) => void;
@@ -72,6 +74,9 @@ function SearchCard({
         <CardTitle className="font-display text-2xl tracking-tight">{title}</CardTitle>
 
         <CardDescription className="flex min-h-6 flex-wrap items-center gap-2 text-sm">
+          {result.matchSource === "semantic" ? (
+            <Badge variant="secondary">Related recipe</Badge>
+          ) : null}
           {recipe ? (
             <>
               {recipe.total_time ? (
@@ -160,8 +165,11 @@ function SearchCard({
 
 type BrowseResultsGridProps = {
   queryFromUrl: string;
-  results: SearchRecipeResult[];
+  results: BrowseSearchResult[];
+  relatedResultCount: number;
   searchError: string | null;
+  isLoadingRelated: boolean;
+  showLoadRelated: boolean;
   showInitialPrompt: boolean;
   showLoadingGrid: boolean;
   showNoResults: boolean;
@@ -169,6 +177,7 @@ type BrowseResultsGridProps = {
   isLoadingMore: boolean;
   recipeById: Record<string, RecipeRecord>;
   recipeLoadingById: Record<string, boolean>;
+  onLoadRelated: () => void;
   onLoadMore: () => void;
   onCardOpen: (recipeId: string) => void;
 };
@@ -176,7 +185,10 @@ type BrowseResultsGridProps = {
 export function BrowseResultsGrid({
   queryFromUrl,
   results,
+  relatedResultCount,
   searchError,
+  isLoadingRelated,
+  showLoadRelated,
   showInitialPrompt,
   showLoadingGrid,
   showNoResults,
@@ -184,9 +196,12 @@ export function BrowseResultsGrid({
   isLoadingMore,
   recipeById,
   recipeLoadingById,
+  onLoadRelated,
   onLoadMore,
   onCardOpen,
 }: BrowseResultsGridProps) {
+  const isQueryMode = Boolean(queryFromUrl);
+
   return (
     <section className="space-y-5 ff-animate-enter-delayed">
       <h2 className="font-display text-[clamp(1.8rem,3vw,2.4rem)] tracking-tight">
@@ -271,6 +286,26 @@ export function BrowseResultsGrid({
             </div>
           ) : null}
         </>
+      ) : null}
+
+      {isQueryMode && (isLoadingRelated || showLoadRelated) ? (
+        <Card className="border-border/70 bg-muted/20 shadow-none">
+          <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="space-y-1">
+              <CardTitle className="text-lg">Related Recipes</CardTitle>
+              <CardDescription>
+                {isLoadingRelated
+                  ? "Finding related recipes in the background..."
+                  : `${relatedResultCount} related recipes are ready to load.`}
+              </CardDescription>
+            </div>
+            {showLoadRelated ? (
+              <Button type="button" variant="outline" onClick={onLoadRelated}>
+                Load related recipes ({relatedResultCount})
+              </Button>
+            ) : null}
+          </CardHeader>
+        </Card>
       ) : null}
     </section>
   );

--- a/apps/web/src/app/browse/page.test.tsx
+++ b/apps/web/src/app/browse/page.test.tsx
@@ -77,6 +77,30 @@ function listRecipesResponse({
   });
 }
 
+function searchRecipesResponse({
+  query,
+  results = [],
+}: {
+  query: string;
+  results?: Array<{ id: string | null; name: string | null; distance: number | null }>;
+}): Response {
+  return jsonResponse({
+    query,
+    count: results.length,
+    results,
+    success: true,
+  });
+}
+
+function recipeResponseFromId(recipeId: string): Response {
+  const titleById: Record<string, string> = {
+    "recipe-1": "Creamy Pasta",
+    "recipe-2": "Tomato Soup",
+    "recipe-3": "Spicy Noodles",
+  };
+  return recipeResponse(recipeId, titleById[recipeId] ?? "Recipe");
+}
+
 describe("/browse page", () => {
   beforeEach(() => {
     pushMock.mockReset();
@@ -141,25 +165,42 @@ describe("/browse page", () => {
   it("ignores stale load-more responses after switching to query mode", async () => {
     const fetchMock = vi.mocked(fetch);
     const pendingLoadMore = createDeferred<Response>();
-    fetchMock
-      .mockResolvedValueOnce(
-        listRecipesResponse({
-          recipes: [{ id: "recipe-1", title: "Creamy Pasta" }],
-          nextCursor: "cursor-1",
-          hasMore: true,
-        }),
-      )
-      .mockResolvedValueOnce(recipeResponse("recipe-1", "Creamy Pasta"))
-      .mockReturnValueOnce(pendingLoadMore.promise)
-      .mockResolvedValueOnce(
-        jsonResponse({
-          query: "pasta",
-          count: 1,
-          results: [{ id: "recipe-3", name: "Spicy Noodles", distance: 0.08 }],
-          success: true,
-        }),
-      )
-      .mockResolvedValueOnce(recipeResponse("recipe-3", "Spicy Noodles"));
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url === "/api/recipes?limit=12") {
+        return Promise.resolve(
+          listRecipesResponse({
+            recipes: [{ id: "recipe-1", title: "Creamy Pasta" }],
+            nextCursor: "cursor-1",
+            hasMore: true,
+          }),
+        );
+      }
+      if (url === "/api/recipes?limit=12&cursor=cursor-1") {
+        return pendingLoadMore.promise;
+      }
+      if (url.startsWith("/api/search/names?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-3", name: "Spicy Noodles", distance: null }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-3", name: "Spicy Noodles", distance: 0.08 }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/recipes/")) {
+        const recipeId = url.split("/").pop() ?? "recipe-1";
+        return Promise.resolve(recipeResponseFromId(recipeId));
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     const user = userEvent.setup();
     const { rerender } = render(<BrowsePage />);
@@ -202,19 +243,73 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=pasta");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        query: "pasta",
-        count: 0,
-        results: [],
-        success: true,
-      }),
-    );
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?") || url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [],
+          }),
+        );
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     render(<BrowsePage />);
 
     expect(await screen.findByRole("searchbox")).toHaveValue("pasta");
     expect(await screen.findByText('Results for "pasta"')).toBeInTheDocument();
+  });
+
+  it("loads text matches first, then lets users load related recipes", async () => {
+    searchParams = new URLSearchParams("q=pasta");
+
+    const fetchMock = vi.mocked(fetch);
+    const deferredSemantic = createDeferred<Response>();
+    const user = userEvent.setup();
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-1", name: "Creamy Pasta", distance: null }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/search?")) {
+        return deferredSemantic.promise;
+      }
+      if (url.startsWith("/api/recipes/")) {
+        const recipeId = url.split("/").pop() ?? "recipe-1";
+        return Promise.resolve(recipeResponseFromId(recipeId));
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
+
+    render(<BrowsePage />);
+
+    expect(await screen.findByRole("button", { name: "Open Creamy Pasta" })).toBeInTheDocument();
+    expect(await screen.findByText("Related Recipes")).toBeInTheDocument();
+    expect(await screen.findByText("Finding related recipes in the background...")).toBeInTheDocument();
+
+    deferredSemantic.resolve(
+      searchRecipesResponse({
+        query: "pasta",
+        results: [
+          { id: "recipe-1", name: "Creamy Pasta", distance: 0.05 },
+          { id: "recipe-3", name: "Spicy Noodles", distance: 0.08 },
+        ],
+      }),
+    );
+
+    const loadRelatedButton = await screen.findByRole("button", {
+      name: "Load related recipes (1)",
+    });
+    await user.click(loadRelatedButton);
+
+    expect(await screen.findByRole("button", { name: "Open Spicy Noodles" })).toBeInTheDocument();
   });
 
   it("pushes normalized query to URL on submit", async () => {
@@ -223,7 +318,8 @@ describe("/browse page", () => {
     render(<BrowsePage />);
 
     await user.type(screen.getByRole("searchbox"), "  creamy pasta  ");
-    await user.click(screen.getByRole("button", { name: /^Search$/i }));
+    const searchButton = await screen.findByRole("button", { name: /^Search$/i });
+    await user.click(searchButton);
 
     expect(pushMock).toHaveBeenCalledWith("/browse?q=creamy+pasta", { scroll: false });
   });
@@ -232,14 +328,18 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=pasta");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        query: "pasta",
-        count: 0,
-        results: [],
-        success: true,
-      }),
-    );
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?") || url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [],
+          }),
+        );
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     const user = userEvent.setup();
     render(<BrowsePage />);
@@ -254,16 +354,29 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=pasta");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse({
-          query: "pasta",
-          count: 1,
-          results: [{ id: "recipe-1", name: "Creamy Pasta", distance: 0.05 }],
-          success: true,
-        }),
-      )
-      .mockResolvedValueOnce(recipeResponse());
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-1", name: "Creamy Pasta", distance: null }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-1", name: "Creamy Pasta", distance: 0.05 }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/recipes/")) {
+        return Promise.resolve(recipeResponse());
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     const user = userEvent.setup();
     render(<BrowsePage />);
@@ -273,7 +386,7 @@ describe("/browse page", () => {
     });
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenCalled();
     });
 
     await user.click(openCardButton);
@@ -287,16 +400,29 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=pasta&recipe=recipe-1");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock
-      .mockResolvedValueOnce(
-        jsonResponse({
-          query: "pasta",
-          count: 1,
-          results: [{ id: "recipe-1", name: "Creamy Pasta", distance: 0.05 }],
-          success: true,
-        }),
-      )
-      .mockResolvedValueOnce(recipeResponse());
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-1", name: "Creamy Pasta", distance: null }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [{ id: "recipe-1", name: "Creamy Pasta", distance: 0.05 }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/recipes/")) {
+        return Promise.resolve(recipeResponse());
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     const user = userEvent.setup();
     render(<BrowsePage />);
@@ -315,14 +441,18 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=kimchi");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        query: "kimchi",
-        count: 0,
-        results: [],
-        success: true,
-      }),
-    );
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?") || url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "kimchi",
+            results: [],
+          }),
+        );
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     render(<BrowsePage />);
 
@@ -333,14 +463,28 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=pasta");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValue(
-      jsonResponse(
-        {
-          detail: "Backend unavailable",
-        },
-        500,
-      ),
-    );
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
+            results: [],
+          }),
+        );
+      }
+      if (url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              detail: "Backend unavailable",
+            },
+            500,
+          ),
+        );
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     render(<BrowsePage />);
 
@@ -352,37 +496,47 @@ describe("/browse page", () => {
     searchParams = new URLSearchParams("q=pasta&recipe=recipe-1");
 
     const fetchMock = vi.mocked(fetch);
-    fetchMock
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
+    fetchMock.mockImplementation((input) => {
+      const url = String(input);
+      if (url.startsWith("/api/search/names?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
             query: "pasta",
-            count: 1,
+            results: [{ id: "recipe-1", name: "Creamy Pasta", distance: null }],
+          }),
+        );
+      }
+      if (url.startsWith("/api/search?")) {
+        return Promise.resolve(
+          searchRecipesResponse({
+            query: "pasta",
             results: [{ id: "recipe-1", name: "Creamy Pasta", distance: 0.05 }],
-            success: true,
           }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            recipe: {
-              id: "recipe-1",
-              title: "Creamy Pasta",
-              servings: "2",
-              total_time: "20 minutes",
-              source_url: null,
-              created_at: null,
-              updated_at: null,
-              ingredients: ["Pasta", "Cream"],
-              instructions: ["Cook pasta", "Add sauce"],
-            },
-            success: true,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        ),
-      );
+        );
+      }
+      if (url.startsWith("/api/recipes/")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              recipe: {
+                id: "recipe-1",
+                title: "Creamy Pasta",
+                servings: "2",
+                total_time: "20 minutes",
+                source_url: null,
+                created_at: null,
+                updated_at: null,
+                ingredients: ["Pasta", "Cream"],
+                instructions: ["Cook pasta", "Add sauce"],
+              },
+              success: true,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(listRecipesResponse());
+    });
 
     render(<BrowsePage />);
 

--- a/apps/web/src/app/browse/page.tsx
+++ b/apps/web/src/app/browse/page.tsx
@@ -13,8 +13,11 @@ export default function BrowsePage() {
     queryFromUrl,
     queryInput,
     results,
+    relatedResultCount,
     searchError,
     isSearching,
+    isLoadingRelated,
+    showLoadRelated,
     recipeById,
     recipeLoadingById,
     recipeIdFromUrl,
@@ -29,6 +32,7 @@ export default function BrowsePage() {
     isLoadingMore,
     handleSearchSubmit,
     handleQueryInputChange,
+    handleLoadRelated,
     handleLoadMore,
     openRecipeModal,
     closeRecipeModal,
@@ -48,23 +52,27 @@ export default function BrowsePage() {
             description="Browse your latest recipes or search by dish, ingredient, or cuisine."
             contentClassName="max-w-4xl"
           >
-              <BrowseSearchForm
-                queryInput={queryInput}
-                isSearching={isSearching}
-                onQueryInputChange={handleQueryInputChange}
-                onSearchSubmit={handleSearchSubmit}
-              />
+            <BrowseSearchForm
+              queryInput={queryInput}
+              isSearching={isSearching}
+              onQueryInputChange={handleQueryInputChange}
+              onSearchSubmit={handleSearchSubmit}
+            />
           </PageHero>
 
           <BrowseResultsGrid
             queryFromUrl={queryFromUrl}
             results={results}
+            relatedResultCount={relatedResultCount}
             searchError={searchError}
+            isLoadingRelated={isLoadingRelated}
+            showLoadRelated={showLoadRelated}
             showInitialPrompt={showInitialPrompt}
             showLoadingGrid={showLoadingGrid}
             showNoResults={showNoResults}
             showLoadMore={showLoadMore}
             isLoadingMore={isLoadingMore}
+            onLoadRelated={handleLoadRelated}
             recipeById={recipeById}
             recipeLoadingById={recipeLoadingById}
             onLoadMore={handleLoadMore}

--- a/apps/web/src/app/browse/use-browse-data.ts
+++ b/apps/web/src/app/browse/use-browse-data.ts
@@ -11,39 +11,83 @@ import type {
 
 import {
   MIN_QUERY_LENGTH,
+  MIN_TEXT_MATCH_QUERY_LENGTH,
   getErrorMessage,
   getRecipeClient,
   listRecipesClient,
   searchRecipesClient,
+  searchRecipesByNameClient,
 } from "./browse-api";
 import { buildBrowseHref, normalizeParam } from "./browse-utils";
 
 const SEARCH_LIMIT = 12;
 
 type NavigationMode = "push" | "replace";
+type SearchMatchSource = "browse" | "text" | "semantic";
+
+export type BrowseSearchResult = SearchRecipeResult & {
+  matchSource: SearchMatchSource;
+  semanticDistance: number | null;
+};
 
 type DefaultListCache = {
-  results: SearchRecipeResult[];
+  results: BrowseSearchResult[];
   nextCursor: string | null;
   hasMore: boolean;
 };
 
-function toSearchResults(recipes: RecipeListItem[]): SearchRecipeResult[] {
+type SearchCacheEntry = {
+  baseResults: BrowseSearchResult[];
+  relatedResults: BrowseSearchResult[];
+};
+
+function toBrowseResults(recipes: RecipeListItem[]): BrowseSearchResult[] {
   return recipes.map((recipe) => ({
     id: recipe.id,
     name: recipe.title,
     distance: null,
+    matchSource: "browse",
+    semanticDistance: null,
   }));
 }
 
-function mergeSearchResults(
-  currentResults: SearchRecipeResult[],
-  incomingResults: SearchRecipeResult[],
-): SearchRecipeResult[] {
+function getSearchResultKey(result: Pick<SearchRecipeResult, "id" | "name" | "distance">) {
+  return result.id ?? `${result.name ?? ""}-${result.distance ?? ""}`;
+}
+
+function dedupeSearchResults(results: SearchRecipeResult[]): SearchRecipeResult[] {
   const seen = new Set<string>();
-  const merged: SearchRecipeResult[] = [];
+  const deduped: SearchRecipeResult[] = [];
+  for (const result of results) {
+    const key = getSearchResultKey(result);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(result);
+  }
+  return deduped;
+}
+
+function toMatchSourceResults(
+  results: SearchRecipeResult[],
+  source: "text" | "semantic",
+): BrowseSearchResult[] {
+  return dedupeSearchResults(results).map((result) => ({
+    ...result,
+    matchSource: source,
+    semanticDistance: source === "semantic" ? result.distance ?? null : null,
+  }));
+}
+
+function mergeBrowseResults(
+  currentResults: BrowseSearchResult[],
+  incomingResults: BrowseSearchResult[],
+): BrowseSearchResult[] {
+  const seen = new Set<string>();
+  const merged: BrowseSearchResult[] = [];
   for (const result of [...currentResults, ...incomingResults]) {
-    const key = result.id ?? `${result.name ?? ""}-${result.distance ?? ""}`;
+    const key = getSearchResultKey(result);
     if (seen.has(key)) {
       continue;
     }
@@ -51,6 +95,14 @@ function mergeSearchResults(
     merged.push(result);
   }
   return merged;
+}
+
+function getRelatedSemanticResults(
+  baseResults: BrowseSearchResult[],
+  semanticResults: BrowseSearchResult[],
+): BrowseSearchResult[] {
+  const baseKeys = new Set(baseResults.map((result) => getSearchResultKey(result)));
+  return semanticResults.filter((result) => !baseKeys.has(getSearchResultKey(result)));
 }
 
 export function useBrowseData() {
@@ -61,9 +113,12 @@ export function useBrowseData() {
   const recipeIdFromUrl = normalizeParam(searchParams.get("recipe"));
 
   const [queryInput, setQueryInput] = useState(queryFromUrl);
-  const [results, setResults] = useState<SearchRecipeResult[]>([]);
+  const [results, setResults] = useState<BrowseSearchResult[]>([]);
+  const [relatedResults, setRelatedResults] = useState<BrowseSearchResult[]>([]);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [isSearching, setIsSearching] = useState(false);
+  const [isLoadingRelated, setIsLoadingRelated] = useState(false);
+  const [hasLoadedRelated, setHasLoadedRelated] = useState(false);
   const [defaultListNextCursor, setDefaultListNextCursor] = useState<string | null>(
     null,
   );
@@ -78,7 +133,7 @@ export function useBrowseData() {
   const [selectedRecipeLoading, setSelectedRecipeLoading] = useState(false);
   const [selectedRecipeError, setSelectedRecipeError] = useState<string | null>(null);
 
-  const searchCacheRef = useRef<Record<string, SearchRecipeResult[]>>({});
+  const searchCacheRef = useRef<Record<string, SearchCacheEntry>>({});
   const defaultListCacheRef = useRef<DefaultListCache | null>(null);
   const recipeCacheRef = useRef<Record<string, RecipeRecord>>({});
   const inFlightRecipeRef = useRef<Record<string, Promise<RecipeRecord>>>({});
@@ -162,7 +217,7 @@ export function useBrowseData() {
   }, []);
 
   const prefetchResultDetails = useCallback(
-    (searchResults: SearchRecipeResult[]) => {
+    (searchResults: BrowseSearchResult[]) => {
       const ids = [
         ...new Set(
           searchResults
@@ -187,17 +242,23 @@ export function useBrowseData() {
         const cachedDefault = defaultListCacheRef.current;
         if (cachedDefault) {
           setResults(cachedDefault.results);
+          setRelatedResults([]);
+          setHasLoadedRelated(false);
           setDefaultListNextCursor(cachedDefault.nextCursor);
           setDefaultListHasMore(cachedDefault.hasMore);
           setSearchError(null);
           setIsSearching(false);
+          setIsLoadingRelated(false);
           prefetchResultDetails(cachedDefault.results);
           return;
         }
 
         setIsSearching(true);
+        setIsLoadingRelated(false);
         setSearchError(null);
         setResults([]);
+        setRelatedResults([]);
+        setHasLoadedRelated(false);
         setDefaultListNextCursor(null);
         setDefaultListHasMore(false);
 
@@ -207,7 +268,7 @@ export function useBrowseData() {
             return;
           }
 
-          const nextResults = toSearchResults(listResponse.recipes ?? []);
+          const nextResults = toBrowseResults(listResponse.recipes ?? []);
           const nextCursor = listResponse.next_cursor ?? null;
           const hasMore = Boolean(listResponse.has_more && nextCursor);
 
@@ -237,48 +298,125 @@ export function useBrowseData() {
 
       if (query.length < MIN_QUERY_LENGTH) {
         setResults([]);
+        setRelatedResults([]);
+        setHasLoadedRelated(false);
         setDefaultListNextCursor(null);
         setDefaultListHasMore(false);
+        setIsLoadingRelated(false);
         setSearchError("Search query must be at least 2 characters.");
         setIsSearching(false);
         return;
       }
 
-      const cachedResults = searchCacheRef.current[query];
-      if (cachedResults) {
-        setResults(cachedResults);
+      const cachedSearch = searchCacheRef.current[query];
+      if (cachedSearch) {
+        setResults(cachedSearch.baseResults);
+        setRelatedResults(cachedSearch.relatedResults);
+        setHasLoadedRelated(false);
         setDefaultListNextCursor(null);
         setDefaultListHasMore(false);
         setSearchError(null);
         setIsSearching(false);
-        prefetchResultDetails(cachedResults);
+        setIsLoadingRelated(false);
+        prefetchResultDetails(cachedSearch.baseResults);
+        if (cachedSearch.relatedResults.length > 0) {
+          prefetchResultDetails(cachedSearch.relatedResults);
+        }
         return;
       }
 
       setIsSearching(true);
+      setIsLoadingRelated(false);
       setSearchError(null);
       setResults([]);
+      setRelatedResults([]);
+      setHasLoadedRelated(false);
       setDefaultListNextCursor(null);
       setDefaultListHasMore(false);
 
+      let baseResults: BrowseSearchResult[] = [];
+      let useSemanticAsPrimary = query.length < MIN_TEXT_MATCH_QUERY_LENGTH;
+
+      if (!useSemanticAsPrimary) {
+        try {
+          const textResponse = await searchRecipesByNameClient(query, SEARCH_LIMIT);
+          if (searchRequestIdRef.current !== requestId) {
+            return;
+          }
+
+          baseResults = toMatchSourceResults(textResponse.results ?? [], "text");
+          setResults(baseResults);
+          setIsSearching(false);
+          prefetchResultDetails(baseResults);
+        } catch {
+          if (searchRequestIdRef.current !== requestId) {
+            return;
+          }
+          useSemanticAsPrimary = true;
+        }
+      }
+
+      if (!useSemanticAsPrimary) {
+        setIsLoadingRelated(true);
+      }
+
       try {
-        const searchResponse = await searchRecipesClient(query, SEARCH_LIMIT);
+        const semanticResponse = await searchRecipesClient(query, SEARCH_LIMIT);
         if (searchRequestIdRef.current !== requestId) {
           return;
         }
 
-        const nextResults = searchResponse.results ?? [];
-        searchCacheRef.current[query] = nextResults;
-        setResults(nextResults);
-        setIsSearching(false);
-        prefetchResultDetails(nextResults);
+        const semanticResults = toMatchSourceResults(
+          semanticResponse.results ?? [],
+          "semantic",
+        );
+
+        if (useSemanticAsPrimary) {
+          searchCacheRef.current[query] = {
+            baseResults: semanticResults,
+            relatedResults: [],
+          };
+
+          setResults(semanticResults);
+          setRelatedResults([]);
+          setIsSearching(false);
+          setIsLoadingRelated(false);
+          prefetchResultDetails(semanticResults);
+          return;
+        }
+
+        const relatedOnly = getRelatedSemanticResults(baseResults, semanticResults);
+        searchCacheRef.current[query] = {
+          baseResults,
+          relatedResults: relatedOnly,
+        };
+
+        setRelatedResults(relatedOnly);
+        setIsLoadingRelated(false);
+        if (relatedOnly.length > 0) {
+          prefetchResultDetails(relatedOnly);
+        }
       } catch (error) {
         if (searchRequestIdRef.current !== requestId) {
           return;
         }
+
+        const semanticErrorMessage = getErrorMessage(error, "Search request failed.");
+        setIsLoadingRelated(false);
+
+        if (!useSemanticAsPrimary && baseResults.length > 0) {
+          searchCacheRef.current[query] = {
+            baseResults,
+            relatedResults: [],
+          };
+          setIsSearching(false);
+          return;
+        }
+
         setResults([]);
+        setRelatedResults([]);
         setIsSearching(false);
-        setSearchError(getErrorMessage(error, "Search request failed."));
+        setSearchError(semanticErrorMessage);
       }
     },
     [prefetchResultDetails],
@@ -336,8 +474,11 @@ export function useBrowseData() {
   const hasQuery = Boolean(queryFromUrl);
   const hasModal = Boolean(recipeIdFromUrl);
   const showInitialPrompt = false;
+  const showLoadRelated =
+    hasQuery && !searchError && relatedResults.length > 0 && !hasLoadedRelated;
   const showLoadingGrid = isSearching && !results.length;
-  const showNoResults = !searchError && !isSearching && !results.length;
+  const showNoResults =
+    !searchError && !isSearching && !results.length && !isLoadingRelated && !showLoadRelated;
   const showLoadMore = !hasQuery && !searchError && results.length > 0 && defaultListHasMore;
 
   function handleSearchSubmit() {
@@ -367,6 +508,15 @@ export function useBrowseData() {
     setBrowseUrl(queryFromUrl, undefined, "replace");
   }
 
+  function handleLoadRelated() {
+    if (!showLoadRelated) {
+      return;
+    }
+
+    setResults((prev) => mergeBrowseResults(prev, relatedResults));
+    setHasLoadedRelated(true);
+  }
+
   async function handleLoadMore() {
     if (hasQuery || isLoadingMore || !defaultListHasMore || !defaultListNextCursor) {
       return;
@@ -380,14 +530,14 @@ export function useBrowseData() {
       if (!isBrowseModeRef.current) {
         return;
       }
-      const incomingResults = toSearchResults(listResponse.recipes ?? []);
+      const incomingResults = toBrowseResults(listResponse.recipes ?? []);
       const nextCursor = listResponse.next_cursor ?? null;
       const hasMore = Boolean(listResponse.has_more && nextCursor);
 
       setDefaultListNextCursor(nextCursor);
       setDefaultListHasMore(hasMore);
       setResults((prev) => {
-        const merged = mergeSearchResults(prev, incomingResults);
+        const merged = mergeBrowseResults(prev, incomingResults);
         defaultListCacheRef.current = {
           results: merged,
           nextCursor,
@@ -410,8 +560,11 @@ export function useBrowseData() {
     queryFromUrl,
     queryInput,
     results,
+    relatedResultCount: relatedResults.length,
     searchError,
     isSearching,
+    isLoadingRelated,
+    showLoadRelated,
     recipeById,
     recipeLoadingById,
     recipeIdFromUrl,
@@ -426,6 +579,7 @@ export function useBrowseData() {
     isLoadingMore,
     handleSearchSubmit,
     handleQueryInputChange,
+    handleLoadRelated,
     handleLoadMore,
     openRecipeModal,
     closeRecipeModal,


### PR DESCRIPTION
This PR updates browse search to prioritize fast name/text matches and run semantic search in the background. Related semantic hits are now user-controlled via a 'Load related recipes' CTA instead of auto-merging and metric chips, with the CTA positioned below primary results. Browse data/state handling was refactored to support base vs related result sets, plus stale-request-safe behavior and existing list pagination/modal behavior. Browse page tests were expanded/updated for the new two-phase flow, and targeted lint/tests pass.