### PR TITLE
Add include_test_data support across recipe and experiment APIs

### DIFF
--- a/app/api/schemas/experiment.py
+++ b/app/api/schemas/experiment.py
@@ -10,6 +10,7 @@ class ExperimentThreadCreateRequest(BaseModel):
     mode: ExperimentMode = "invent_new"
     title: str | None = Field(default=None, min_length=1, max_length=140)
     context_recipe_ids: list[UUID] = Field(default_factory=list)
+    include_test_data: bool = False
 
 
 class ExperimentMessageCreateRequest(BaseModel):
@@ -17,3 +18,4 @@ class ExperimentMessageCreateRequest(BaseModel):
     context_recipe_ids: list[UUID] | None = None
     attach_recipe_ids: list[UUID] | None = None
     attach_recipe_names: list[str] | None = None
+    include_test_data: bool = False

--- a/app/api/v1/endpoints/experiments.py
+++ b/app/api/v1/endpoints/experiments.py
@@ -46,6 +46,7 @@ def create_experiment_thread(
             mode=payload.mode,
             title=payload.title,
             context_recipe_ids=_to_string_ids(payload.context_recipe_ids),
+            include_test_data=payload.include_test_data,
         )
         return {"thread": thread, "success": True}
     except ExperimentValidationError as e:
@@ -94,6 +95,10 @@ def get_experiment_thread(
         le=500,
         description="Maximum number of messages to include with the thread payload.",
     ),
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data in thread context.",
+    ),
     experiment_service=experiment_service_dep,
 ) -> dict:
     thread_id_str = str(thread_id)
@@ -101,6 +106,7 @@ def get_experiment_thread(
         thread = experiment_service.get_thread(
             thread_id=thread_id_str,
             message_limit=message_limit,
+            include_test_data=include_test_data,
         )
         return {"thread": thread, "success": True}
     except ExperimentThreadNotFoundError as e:
@@ -137,6 +143,7 @@ def create_experiment_message(
             context_recipe_ids=context_recipe_ids,
             attach_recipe_ids=attach_recipe_ids,
             attach_recipe_names=attach_recipe_names,
+            include_test_data=payload.include_test_data,
         )
         return {"thread_id": thread_id_str, **response_payload, "success": True}
     except ExperimentThreadNotFoundError as e:
@@ -187,6 +194,7 @@ def stream_experiment_message(
                 context_recipe_ids=context_recipe_ids,
                 attach_recipe_ids=attach_recipe_ids,
                 attach_recipe_names=attach_recipe_names,
+                include_test_data=payload.include_test_data,
             )
             for event_payload in event_iterator:
                 event_name = str(event_payload.get("event", "message"))

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -36,11 +36,16 @@ recipe_search_reranker_service_dep = Depends(get_recipe_search_reranker_service)
 grocery_list_aggregation_service_dep = Depends(get_grocery_list_aggregation_service)
 
 
-def _semantic_search_cache_key(normalized_query: str, limit: int) -> str:
+def _semantic_search_cache_key(
+    normalized_query: str,
+    limit: int,
+    include_test_data: bool,
+) -> str:
     return hash_cache_key(
         "semantic_search",
         normalized_query,
         str(limit),
+        str(include_test_data),
         str(settings.SEMANTIC_SEARCH_MAX_DISTANCE),
         str(settings.SEMANTIC_SEARCH_RERANK_ENABLED),
         str(settings.SEMANTIC_SEARCH_RERANK_CANDIDATE_COUNT),
@@ -89,7 +94,10 @@ def process_and_store_recipe(
                 "error": "Duplicate recipe detected but no recipe_id was returned",
                 "success": False,
             }
-        recipe_data = recipe_manager.get_full_recipe(recipe_id)
+        recipe_data = recipe_manager.get_full_recipe(
+            recipe_id,
+            include_test_data=ingestion_request.is_test,
+        )
         if not recipe_data:
             logger.error(f"Duplicate recipe found but not retrieved: {recipe_id}")
             raise HTTPException(
@@ -105,7 +113,10 @@ def process_and_store_recipe(
             "message": "Duplicate recipe found; returning existing recipe.",
         }
 
-    recipe_data = recipe_manager.get_full_recipe(recipe_id)
+    recipe_data = recipe_manager.get_full_recipe(
+        recipe_id,
+        include_test_data=ingestion_request.is_test,
+    )
     if not recipe_data:
         logger.error(f"Recipe stored but not found: {recipe_id}")
         raise HTTPException(
@@ -180,6 +191,10 @@ def list_recipes(
             "Opaque cursor token from the previous response for paginated listing."
         ),
     ),
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data.",
+    ),
     recipe_manager=recipe_manager_dep,
 ) -> dict:
     """
@@ -199,6 +214,7 @@ def list_recipes(
             limit=limit + 1,
             cursor_created_at=cursor_created_at,
             cursor_id=cursor_id,
+            include_test_data=include_test_data,
         )
         has_more = len(page_with_sentinel) > limit
         recipes_page = page_with_sentinel[:limit]
@@ -240,6 +256,10 @@ def semantic_search_recipes(
         le=50,
         description="Maximum number of similar recipes to return.",
     ),
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data.",
+    ),
     recipe_manager=recipe_manager_dep,
     embeddings_service=recipe_embeddings_service_dep,
     reranker_service=recipe_search_reranker_service_dep,
@@ -256,7 +276,11 @@ def semantic_search_recipes(
             status_code=422,
             detail="Query must contain at least 2 non-whitespace characters.",
         )
-    cache_key = _semantic_search_cache_key(normalized_query, limit)
+    cache_key = _semantic_search_cache_key(
+        normalized_query=normalized_query,
+        limit=limit,
+        include_test_data=include_test_data,
+    )
     cached_response = semantic_search_cache.get(cache_key)
     if cached_response is not None:
         logger.info(
@@ -284,11 +308,16 @@ def semantic_search_recipes(
             embedding_type="title_ingredients",
             limit=candidate_limit,
             max_distance=settings.SEMANTIC_SEARCH_MAX_DISTANCE,
+            include_test_data=include_test_data,
         )
         if settings.SEMANTIC_SEARCH_RERANK_ENABLED and len(matches) > 1:
             ranked_items = []
             try:
-                rerank_candidates = build_rerank_candidates(matches, recipe_manager)
+                rerank_candidates = build_rerank_candidates(
+                    matches,
+                    recipe_manager,
+                    include_test_data=include_test_data,
+                )
                 ranked_items = reranker_service.rerank(
                     query=normalized_query,
                     candidates=rerank_candidates,
@@ -343,6 +372,10 @@ def search_recipes_by_name(
         le=10,
         description="Maximum number of title matches to return.",
     ),
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data.",
+    ),
     recipe_manager=recipe_manager_dep,
 ) -> dict:
     normalized_query = normalize_search_query(query)
@@ -356,6 +389,7 @@ def search_recipes_by_name(
         matches = recipe_manager.find_recipes_by_title_query(
             title_query=normalized_query,
             limit=limit,
+            include_test_data=include_test_data,
         )
         results = [
             {
@@ -382,6 +416,10 @@ def search_recipes_by_name(
 @router.post("/grocery-list")
 def create_grocery_list(
     grocery_list_request: GroceryListCreateRequest = GROCERY_LIST_BODY,
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data.",
+    ),
     recipe_manager=recipe_manager_dep,
     grocery_list_aggregation_service=grocery_list_aggregation_service_dep,
 ) -> dict:
@@ -392,7 +430,10 @@ def create_grocery_list(
         dict.fromkeys(str(recipe_id) for recipe_id in grocery_list_request.recipe_ids)
     )
     try:
-        ingredients_by_recipe = recipe_manager.get_ingredients_for_recipes(recipe_ids)
+        ingredients_by_recipe = recipe_manager.get_ingredients_for_recipes(
+            recipe_ids,
+            include_test_data=include_test_data,
+        )
         missing_recipe_ids = [
             recipe_id
             for recipe_id in recipe_ids
@@ -437,7 +478,14 @@ def create_grocery_list(
 
 
 @router.get("/{recipe_id}")
-def get_recipe(recipe_id: str, recipe_manager=recipe_manager_dep) -> dict:
+def get_recipe(
+    recipe_id: str,
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data.",
+    ),
+    recipe_manager=recipe_manager_dep,
+) -> dict:
     """
     Get a complete recipe by its UUID.
 
@@ -447,7 +495,10 @@ def get_recipe(recipe_id: str, recipe_manager=recipe_manager_dep) -> dict:
     logger.info(f"Retrieving recipe with ID: {recipe_id}")
 
     try:
-        recipe_data = recipe_manager.get_full_recipe(recipe_id)
+        recipe_data = recipe_manager.get_full_recipe(
+            recipe_id,
+            include_test_data=include_test_data,
+        )
 
         if not recipe_data:
             logger.warning(f"Recipe not found: {recipe_id}")
@@ -466,7 +517,14 @@ def get_recipe(recipe_id: str, recipe_manager=recipe_manager_dep) -> dict:
 
 
 @router.get("/{recipe_id}/all")
-def get_recipe_all(recipe_id: str, recipe_manager=recipe_manager_dep) -> dict:
+def get_recipe_all(
+    recipe_id: str,
+    include_test_data: bool = Query(
+        default=False,
+        description="Include recipes marked as test data.",
+    ),
+    recipe_manager=recipe_manager_dep,
+) -> dict:
     """
     Get a complete recipe by its UUID, including embeddings.
 
@@ -476,7 +534,10 @@ def get_recipe_all(recipe_id: str, recipe_manager=recipe_manager_dep) -> dict:
     logger.info(f"Retrieving full recipe with embeddings for ID: {recipe_id}")
 
     try:
-        recipe_data = recipe_manager.get_full_recipe_with_embeddings(recipe_id)
+        recipe_data = recipe_manager.get_full_recipe_with_embeddings(
+            recipe_id,
+            include_test_data=include_test_data,
+        )
 
         if not recipe_data:
             logger.warning(f"Recipe not found: {recipe_id}")

--- a/app/api/v1/helpers/recipe_search.py
+++ b/app/api/v1/helpers/recipe_search.py
@@ -267,7 +267,11 @@ def _rank_matches(
     return ordered_matches, ranked_ids_found
 
 
-def build_rerank_candidates(matches: list[dict], recipe_manager) -> list[dict]:
+def build_rerank_candidates(
+    matches: list[dict],
+    recipe_manager,
+    include_test_data: bool = False,
+) -> list[dict]:
     recipe_ids = []
     for item in matches:
         recipe_id = _normalize_recipe_id(item.get("id"))
@@ -280,6 +284,7 @@ def build_rerank_candidates(matches: list[dict], recipe_manager) -> list[dict]:
             ingredient_previews = recipe_manager.get_ingredient_previews(
                 recipe_ids=recipe_ids,
                 max_ingredients=8,
+                include_test_data=include_test_data,
             )
         except Exception as exc:
             logger.warning(

--- a/app/services/data/managers/experiment_manager.py
+++ b/app/services/data/managers/experiment_manager.py
@@ -43,10 +43,12 @@ WHERE id = %s
 THREAD_EXISTS_SQL = "SELECT 1 FROM experiment_threads WHERE id = %s"
 
 THREAD_CONTEXT_GET_SQL = """
-SELECT recipe_id
-FROM experiment_context_recipes
-WHERE thread_id = %s
-ORDER BY added_at, recipe_id
+SELECT ecr.recipe_id
+FROM experiment_context_recipes ecr
+JOIN recipes r ON r.id = ecr.recipe_id
+WHERE ecr.thread_id = %s
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+ORDER BY ecr.added_at, ecr.recipe_id
 """
 
 THREAD_CONTEXT_INSERT_SQL = """
@@ -200,10 +202,14 @@ class ExperimentManager(BaseManager):
             cursor.execute(THREAD_CONTEXT_INSERT_SQL, (thread_id, recipe_id))
         return normalized_ids
 
-    def get_context_recipe_ids(self, thread_id: str) -> list[str]:
+    def get_context_recipe_ids(
+        self,
+        thread_id: str,
+        include_test_data: bool = False,
+    ) -> list[str]:
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(THREAD_CONTEXT_GET_SQL, (thread_id,))
+                cursor.execute(THREAD_CONTEXT_GET_SQL, (thread_id, include_test_data))
                 rows = cursor.fetchall()
                 return [str(row["recipe_id"]) for row in rows]
         except Exception as e:
@@ -240,7 +246,12 @@ class ExperimentManager(BaseManager):
         except Exception as e:
             raise DatabaseError(f"Failed to create experiment thread: {e!s}") from e
 
-    def get_thread(self, thread_id: str, message_limit: int = 100) -> dict | None:
+    def get_thread(
+        self,
+        thread_id: str,
+        message_limit: int = 100,
+        include_test_data: bool = False,
+    ) -> dict | None:
         query_limit = max(1, min(int(message_limit), 500))
         try:
             with self.get_db_context() as (_conn, cursor):
@@ -250,7 +261,7 @@ class ExperimentManager(BaseManager):
                     return None
 
                 thread = self._serialize_thread(dict(row))
-                cursor.execute(THREAD_CONTEXT_GET_SQL, (thread_id,))
+                cursor.execute(THREAD_CONTEXT_GET_SQL, (thread_id, include_test_data))
                 context_rows = cursor.fetchall()
                 thread["context_recipe_ids"] = [
                     str(context_row["recipe_id"]) for context_row in context_rows

--- a/app/services/data/managers/recipe_book_manager.py
+++ b/app/services/data/managers/recipe_book_manager.py
@@ -7,45 +7,60 @@ from .base import BaseManager
 
 RECIPE_BOOK_WITH_COUNT_BY_ID_SQL = """
 SELECT rb.*,
-    COUNT(rbr.recipe_id)::int AS recipe_count
+    COUNT(r.id)::int AS recipe_count
 FROM recipe_books rb
 LEFT JOIN recipe_book_recipes rbr ON rbr.recipe_book_id = rb.id
+LEFT JOIN recipes r
+    ON r.id = rbr.recipe_id
+    AND COALESCE(r.is_test_data, FALSE) = FALSE
 WHERE rb.id = %s
 GROUP BY rb.id
 """
 RECIPE_BOOK_WITH_COUNT_BY_NAME_SQL = """
 SELECT rb.*,
-    COUNT(rbr.recipe_id)::int AS recipe_count
+    COUNT(r.id)::int AS recipe_count
 FROM recipe_books rb
 LEFT JOIN recipe_book_recipes rbr ON rbr.recipe_book_id = rb.id
+LEFT JOIN recipes r
+    ON r.id = rbr.recipe_id
+    AND COALESCE(r.is_test_data, FALSE) = FALSE
 WHERE rb.normalized_name = %s
 GROUP BY rb.id
 """
 RECIPE_BOOKS_LIST_SQL = """
 SELECT rb.*,
-    COUNT(rbr.recipe_id)::int AS recipe_count
+    COUNT(r.id)::int AS recipe_count
 FROM recipe_books rb
 LEFT JOIN recipe_book_recipes rbr ON rbr.recipe_book_id = rb.id
+LEFT JOIN recipes r
+    ON r.id = rbr.recipe_id
+    AND COALESCE(r.is_test_data, FALSE) = FALSE
 GROUP BY rb.id
 ORDER BY rb.created_at DESC
 LIMIT %s
 """
 RECIPE_IDS_FOR_BOOK_SQL = """
-SELECT recipe_id
-FROM recipe_book_recipes
-WHERE recipe_book_id = %s
-ORDER BY added_at ASC
+SELECT rbr.recipe_id
+FROM recipe_book_recipes rbr
+JOIN recipes r ON r.id = rbr.recipe_id
+WHERE rbr.recipe_book_id = %s
+  AND COALESCE(r.is_test_data, FALSE) = FALSE
+ORDER BY rbr.added_at ASC
 """
 RECIPE_BOOKS_FOR_RECIPE_SQL = """
 SELECT rb.*,
     (
         SELECT COUNT(*)::int
         FROM recipe_book_recipes rbr2
+        JOIN recipes r2 ON r2.id = rbr2.recipe_id
         WHERE rbr2.recipe_book_id = rb.id
+          AND COALESCE(r2.is_test_data, FALSE) = FALSE
     ) AS recipe_count
 FROM recipe_books rb
 JOIN recipe_book_recipes rbr ON rbr.recipe_book_id = rb.id
+JOIN recipes r ON r.id = rbr.recipe_id
 WHERE rbr.recipe_id = %s
+  AND COALESCE(r.is_test_data, FALSE) = FALSE
 ORDER BY rb.name ASC
 """
 INSERT_RECIPE_BOOK_SQL = """
@@ -64,14 +79,26 @@ DELETE FROM recipe_book_recipes
 WHERE recipe_book_id = %s AND recipe_id = %s
 """
 RECIPE_BOOK_EXISTS_SQL = "SELECT 1 FROM recipe_books WHERE id = %s"
-RECIPE_EXISTS_SQL = "SELECT 1 FROM recipes WHERE id = %s"
+RECIPE_EXISTS_SQL = """
+SELECT 1
+FROM recipes
+WHERE id = %s
+  AND COALESCE(is_test_data, FALSE) = FALSE
+"""
 RECIPE_BOOK_STATS_SQL = """
 SELECT
     (SELECT COUNT(*)::int FROM recipe_books) AS total_recipe_books,
-    (SELECT COUNT(*)::int FROM recipe_book_recipes) AS total_recipe_book_links,
     (
-        SELECT COUNT(DISTINCT recipe_id)::int
-        FROM recipe_book_recipes
+        SELECT COUNT(*)::int
+        FROM recipe_book_recipes rbr
+        JOIN recipes r ON r.id = rbr.recipe_id
+        WHERE COALESCE(r.is_test_data, FALSE) = FALSE
+    ) AS total_recipe_book_links,
+    (
+        SELECT COUNT(DISTINCT rbr.recipe_id)::int
+        FROM recipe_book_recipes rbr
+        JOIN recipes r ON r.id = rbr.recipe_id
+        WHERE COALESCE(r.is_test_data, FALSE) = FALSE
     ) AS unique_recipes_in_books
 """
 

--- a/app/services/data/managers/recipe_manager.py
+++ b/app/services/data/managers/recipe_manager.py
@@ -23,6 +23,7 @@ LEFT JOIN LATERAL (
     WHERE recipe_id = r.id
 ) s ON true
 WHERE r.id = %s
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
 """
 EMBEDDINGS_SELECT_SQL = """
 SELECT id, embedding_type, embedding, created_at
@@ -38,15 +39,18 @@ SELECT
 FROM recipe_embeddings e
 JOIN recipes r ON r.id = e.recipe_id
 WHERE e.embedding_type = %s
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
   AND e.embedding <=> %s::vector <= %s
 ORDER BY distance
 LIMIT %s
 """
 INGREDIENTS_FOR_RECIPES_SQL = """
-SELECT recipe_id, ingredient_text
-FROM recipe_ingredients
-WHERE recipe_id = ANY(%s::uuid[])
-ORDER BY recipe_id, order_index
+SELECT ri.recipe_id, ri.ingredient_text
+FROM recipe_ingredients ri
+JOIN recipes r ON r.id = ri.recipe_id
+WHERE ri.recipe_id = ANY(%s::uuid[])
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+ORDER BY ri.recipe_id, ri.order_index
 """
 ALL_INGREDIENTS_FOR_RECIPES_SQL = """
 SELECT
@@ -59,6 +63,7 @@ SELECT
 FROM recipes r
 LEFT JOIN recipe_ingredients i ON i.recipe_id = r.id
 WHERE r.id = ANY(%s::uuid[])
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
 GROUP BY r.id
 """
 RECIPES_PAGE_SQL = """
@@ -72,6 +77,7 @@ SELECT
     created_at,
     updated_at
 FROM recipes
+WHERE (%s OR COALESCE(is_test_data, FALSE) = FALSE)
 ORDER BY created_at DESC, id DESC
 LIMIT %s
 """
@@ -87,6 +93,7 @@ SELECT
     updated_at
 FROM recipes
 WHERE (created_at, id) < (%s::timestamp, %s::uuid)
+  AND (%s OR COALESCE(is_test_data, FALSE) = FALSE)
 ORDER BY created_at DESC, id DESC
 LIMIT %s
 """
@@ -94,6 +101,7 @@ RECIPES_BY_TITLE_SQL = """
 SELECT id, title, created_at
 FROM recipes
 WHERE title ILIKE %s
+  AND (%s OR COALESCE(is_test_data, FALSE) = FALSE)
 ORDER BY
     CASE WHEN lower(title) = lower(%s) THEN 0 ELSE 1 END,
     created_at DESC
@@ -192,8 +200,13 @@ class RecipeManager(BaseManager):
         embedding_id = self._generate_id()
         cursor.execute(sql, (embedding_id, recipe_id, embedding_type, embedding))
 
-    def _fetch_recipe_with_children(self, cursor, recipe_id: str) -> Optional[dict]:
-        cursor.execute(RECIPE_WITH_CHILDREN_SQL, (recipe_id,))
+    def _fetch_recipe_with_children(
+        self,
+        cursor,
+        recipe_id: str,
+        include_test_data: bool = False,
+    ) -> Optional[dict]:
+        cursor.execute(RECIPE_WITH_CHILDREN_SQL, (recipe_id, include_test_data))
         row = cursor.fetchone()
         if not row:
             return None
@@ -268,11 +281,17 @@ class RecipeManager(BaseManager):
         except Exception as e:
             raise DatabaseError(f"Failed to create recipe: {e!s}") from e
 
-    def get_full_recipe(self, recipe_id: str) -> Optional[dict]:
+    def get_full_recipe(
+        self, recipe_id: str, include_test_data: bool = False
+    ) -> Optional[dict]:
         """Get a complete recipe with ingredients and instructions"""
         try:
             with self.get_db_context() as (_conn, cursor):
-                recipe_data = self._fetch_recipe_with_children(cursor, recipe_id)
+                recipe_data = self._fetch_recipe_with_children(
+                    cursor=cursor,
+                    recipe_id=recipe_id,
+                    include_test_data=include_test_data,
+                )
                 if not recipe_data:
                     return None
                 return recipe_data
@@ -280,11 +299,17 @@ class RecipeManager(BaseManager):
         except Exception as e:
             raise DatabaseError(f"Failed to get recipe: {e!s}") from e
 
-    def get_full_recipe_with_embeddings(self, recipe_id: str) -> Optional[dict]:
+    def get_full_recipe_with_embeddings(
+        self, recipe_id: str, include_test_data: bool = False
+    ) -> Optional[dict]:
         """Get a complete recipe with ingredients, instructions, and embeddings."""
         try:
             with self.get_db_context() as (_conn, cursor):
-                recipe_data = self._fetch_recipe_with_children(cursor, recipe_id)
+                recipe_data = self._fetch_recipe_with_children(
+                    cursor=cursor,
+                    recipe_id=recipe_id,
+                    include_test_data=include_test_data,
+                )
                 if not recipe_data:
                     return None
 
@@ -299,6 +324,7 @@ class RecipeManager(BaseManager):
         limit: int = 50,
         cursor_created_at: datetime | None = None,
         cursor_id: str | None = None,
+        include_test_data: bool = False,
     ) -> list[dict]:
         """List recipes ordered by newest first with optional cursor pagination."""
         query_limit = max(1, int(limit))
@@ -307,10 +333,10 @@ class RecipeManager(BaseManager):
                 if cursor_created_at is not None and cursor_id is not None:
                     cursor.execute(
                         RECIPES_PAGE_WITH_CURSOR_SQL,
-                        (cursor_created_at, cursor_id, query_limit),
+                        (cursor_created_at, cursor_id, include_test_data, query_limit),
                     )
                 else:
-                    cursor.execute(RECIPES_PAGE_SQL, (query_limit,))
+                    cursor.execute(RECIPES_PAGE_SQL, (include_test_data, query_limit))
                 return [dict(row) for row in cursor.fetchall()]
         except Exception as e:
             raise DatabaseError(f"Failed to list recipes: {e!s}") from e
@@ -319,6 +345,7 @@ class RecipeManager(BaseManager):
         self,
         recipe_ids: list[str],
         max_ingredients: int = 8,
+        include_test_data: bool = False,
     ) -> dict[str, list[str]]:
         """
         Fetch ingredient previews for many recipes in one query.
@@ -343,7 +370,10 @@ class RecipeManager(BaseManager):
 
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(INGREDIENTS_FOR_RECIPES_SQL, (normalized_ids,))
+                cursor.execute(
+                    INGREDIENTS_FOR_RECIPES_SQL,
+                    (normalized_ids, include_test_data),
+                )
                 for row in cursor.fetchall():
                     recipe_id = str(row["recipe_id"])
                     ingredient = row["ingredient_text"]
@@ -355,7 +385,10 @@ class RecipeManager(BaseManager):
             raise DatabaseError(f"Failed to get ingredient previews: {e!s}") from e
 
     def find_recipes_by_title_query(
-        self, title_query: str, limit: int = 5
+        self,
+        title_query: str,
+        limit: int = 5,
+        include_test_data: bool = False,
     ) -> list[dict]:
         normalized_query = (title_query or "").strip()
         if not normalized_query:
@@ -367,7 +400,12 @@ class RecipeManager(BaseManager):
             with self.get_db_context() as (_conn, cursor):
                 cursor.execute(
                     RECIPES_BY_TITLE_SQL,
-                    (like_pattern, normalized_query, query_limit),
+                    (
+                        like_pattern,
+                        include_test_data,
+                        normalized_query,
+                        query_limit,
+                    ),
                 )
                 rows = cursor.fetchall()
                 return [
@@ -382,7 +420,9 @@ class RecipeManager(BaseManager):
             raise DatabaseError(f"Failed to find recipes by title: {e!s}") from e
 
     def get_ingredients_for_recipes(
-        self, recipe_ids: list[str]
+        self,
+        recipe_ids: list[str],
+        include_test_data: bool = False,
     ) -> dict[str, list[str]]:
         """
         Fetch full ingredient lists for many recipes in one query.
@@ -406,7 +446,10 @@ class RecipeManager(BaseManager):
 
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(ALL_INGREDIENTS_FOR_RECIPES_SQL, (normalized_ids,))
+                cursor.execute(
+                    ALL_INGREDIENTS_FOR_RECIPES_SQL,
+                    (normalized_ids, include_test_data),
+                )
                 rows = cursor.fetchall()
                 ingredients_by_recipe: dict[str, list[str]] = {}
                 for row in rows:
@@ -424,6 +467,7 @@ class RecipeManager(BaseManager):
         embedding_type: str,
         limit: int = 10,
         max_distance: float = 0.35,
+        include_test_data: bool = False,
     ) -> list[dict]:
         """Find recipes with embeddings closest to the provided embedding."""
         try:
@@ -433,6 +477,7 @@ class RecipeManager(BaseManager):
                     (
                         embedding,
                         embedding_type,
+                        include_test_data,
                         embedding,
                         max_distance,
                         limit,
@@ -447,18 +492,24 @@ class RecipeManager(BaseManager):
         self,
         embedding: list[float],
         embedding_type: str,
+        include_test_data: bool = False,
     ) -> Optional[dict]:
         """Find the nearest embedding by cosine distance."""
         try:
             with self.get_db_context() as (_conn, cursor):
                 sql = """
-                SELECT recipe_id, embedding_type, embedding <=> %s::vector AS distance
-                FROM recipe_embeddings
-                WHERE embedding_type = %s
+                SELECT
+                    e.recipe_id,
+                    e.embedding_type,
+                    e.embedding <=> %s::vector AS distance
+                FROM recipe_embeddings e
+                JOIN recipes r ON r.id = e.recipe_id
+                WHERE e.embedding_type = %s
+                  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
                 ORDER BY distance
                 LIMIT 1
                 """
-                cursor.execute(sql, (embedding, embedding_type))
+                cursor.execute(sql, (embedding, embedding_type, include_test_data))
                 row = cursor.fetchone()
                 return dict(row) if row else None
         except Exception as e:

--- a/app/services/experiment_service.py
+++ b/app/services/experiment_service.py
@@ -86,14 +86,21 @@ class ExperimentService:
     def _normalize_attach_recipe_ids(recipe_ids: list[str] | None) -> list[str]:
         return ExperimentService._normalize_context_recipe_ids(recipe_ids or [])
 
-    def _validate_recipe_ids(self, recipe_ids: list[str]) -> list[str]:
+    def _validate_recipe_ids(
+        self,
+        recipe_ids: list[str],
+        include_test_data: bool = False,
+    ) -> list[str]:
         normalized_ids = self._normalize_context_recipe_ids(recipe_ids)
         if not normalized_ids:
             return []
 
         missing_ids: list[str] = []
         for recipe_id in normalized_ids:
-            if not self.recipe_manager.get_full_recipe(recipe_id):
+            if not self.recipe_manager.get_full_recipe(
+                recipe_id,
+                include_test_data=include_test_data,
+            ):
                 missing_ids.append(recipe_id)
 
         if missing_ids:
@@ -108,12 +115,16 @@ class ExperimentService:
         mode: str | None = None,
         title: str | None = None,
         context_recipe_ids: list[str] | None = None,
+        include_test_data: bool = False,
     ) -> dict:
         normalized_mode = self._normalize_mode(mode)
         normalized_title = (
             title.strip() if isinstance(title, str) and title.strip() else None
         )
-        validated_context_ids = self._validate_recipe_ids(context_recipe_ids or [])
+        validated_context_ids = self._validate_recipe_ids(
+            context_recipe_ids or [],
+            include_test_data=include_test_data,
+        )
 
         return self.experiment_manager.create_thread(
             mode=normalized_mode,
@@ -126,14 +137,18 @@ class ExperimentService:
         return self.experiment_manager.list_threads(limit=limit)
 
     def _resolve_attach_recipe_names(
-        self, recipe_names: list[str]
+        self,
+        recipe_names: list[str],
+        include_test_data: bool = False,
     ) -> tuple[list[dict], list[str]]:
         attached_recipes: list[dict] = []
         unresolved_names: list[str] = []
 
         for recipe_name in self._normalize_attach_recipe_names(recipe_names):
             matches = self.recipe_manager.find_recipes_by_title_query(
-                recipe_name, limit=1
+                recipe_name,
+                limit=1,
+                include_test_data=include_test_data,
             )
             if not matches:
                 unresolved_names.append(recipe_name)
@@ -142,13 +157,18 @@ class ExperimentService:
         return attached_recipes, unresolved_names
 
     def _resolve_attach_recipe_ids(
-        self, recipe_ids: list[str]
+        self,
+        recipe_ids: list[str],
+        include_test_data: bool = False,
     ) -> tuple[list[dict], list[str]]:
         attached_recipes: list[dict] = []
         unresolved_ids: list[str] = []
 
         for recipe_id in self._normalize_attach_recipe_ids(recipe_ids):
-            recipe = self.recipe_manager.get_full_recipe(recipe_id)
+            recipe = self.recipe_manager.get_full_recipe(
+                recipe_id,
+                include_test_data=include_test_data,
+            )
             if not recipe:
                 unresolved_ids.append(recipe_id)
                 continue
@@ -165,24 +185,44 @@ class ExperimentService:
         self,
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
+        include_test_data: bool = False,
     ) -> tuple[list[dict], list[str]]:
         if attach_recipe_ids:
-            return self._resolve_attach_recipe_ids(attach_recipe_ids)
-        return self._resolve_attach_recipe_names(attach_recipe_names or [])
+            return self._resolve_attach_recipe_ids(
+                attach_recipe_ids,
+                include_test_data=include_test_data,
+            )
+        return self._resolve_attach_recipe_names(
+            attach_recipe_names or [],
+            include_test_data=include_test_data,
+        )
 
-    def get_thread(self, thread_id: str, message_limit: int = 100) -> dict:
+    def get_thread(
+        self,
+        thread_id: str,
+        message_limit: int = 100,
+        include_test_data: bool = False,
+    ) -> dict:
         thread = self.experiment_manager.get_thread(
             thread_id=thread_id,
             message_limit=message_limit,
+            include_test_data=include_test_data,
         )
         if not thread:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         return thread
 
-    def _build_context_payload(self, context_recipe_ids: list[str]) -> list[dict]:
+    def _build_context_payload(
+        self,
+        context_recipe_ids: list[str],
+        include_test_data: bool = False,
+    ) -> list[dict]:
         context_payload: list[dict] = []
         for recipe_id in context_recipe_ids:
-            recipe = self.recipe_manager.get_full_recipe(recipe_id)
+            recipe = self.recipe_manager.get_full_recipe(
+                recipe_id,
+                include_test_data=include_test_data,
+            )
             if not recipe:
                 continue
 
@@ -218,8 +258,12 @@ class ExperimentService:
         user_message: str,
         context_recipe_ids: list[str],
         prior_messages: list[dict],
+        include_test_data: bool = False,
     ) -> str:
-        context_payload = self._build_context_payload(context_recipe_ids)
+        context_payload = self._build_context_payload(
+            context_recipe_ids,
+            include_test_data=include_test_data,
+        )
         history_payload = self._build_history_payload(prior_messages)
         return json.dumps(
             {
@@ -266,12 +310,14 @@ class ExperimentService:
         user_message: str,
         context_recipe_ids: list[str],
         prior_messages: list[dict],
+        include_test_data: bool = False,
     ) -> str:
         user_prompt = self._build_agent_user_prompt(
             mode=mode,
             user_message=user_message,
             context_recipe_ids=context_recipe_ids,
             prior_messages=prior_messages,
+            include_test_data=include_test_data,
         )
 
         try:
@@ -297,17 +343,25 @@ class ExperimentService:
         context_recipe_ids: list[str] | None = None,
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
+        include_test_data: bool = False,
     ) -> dict:
         normalized_content = content.strip()
         if not normalized_content:
             raise ExperimentValidationError("Message content cannot be empty.")
 
-        thread = self.experiment_manager.get_thread(thread_id, message_limit=40)
+        thread = self.experiment_manager.get_thread(
+            thread_id,
+            message_limit=40,
+            include_test_data=include_test_data,
+        )
         if not thread:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
 
         if context_recipe_ids is not None:
-            validated_context_ids = self._validate_recipe_ids(context_recipe_ids)
+            validated_context_ids = self._validate_recipe_ids(
+                context_recipe_ids,
+                include_test_data=include_test_data,
+            )
             self.experiment_manager.set_context_recipe_ids(
                 thread_id=thread_id,
                 context_recipe_ids=validated_context_ids,
@@ -317,6 +371,7 @@ class ExperimentService:
         attached_recipes, unresolved_recipe_names = self._resolve_attach_recipes(
             attach_recipe_ids=attach_recipe_ids,
             attach_recipe_names=attach_recipe_names,
+            include_test_data=include_test_data,
         )
         attachment_message = None
         if attached_recipes:
@@ -361,13 +416,15 @@ class ExperimentService:
             thread_id=thread_id, limit=40
         )
         thread_context_recipe_ids = self.experiment_manager.get_context_recipe_ids(
-            thread_id
+            thread_id,
+            include_test_data=include_test_data,
         )
         assistant_content = self._run_agent_turn(
             mode=thread["mode"],
             user_message=normalized_content,
             context_recipe_ids=thread_context_recipe_ids,
             prior_messages=thread_messages,
+            include_test_data=include_test_data,
         )
 
         assistant_message = self.experiment_manager.create_message(
@@ -378,7 +435,11 @@ class ExperimentService:
         if not assistant_message:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
 
-        updated_thread = self.get_thread(thread_id=thread_id, message_limit=120)
+        updated_thread = self.get_thread(
+            thread_id=thread_id,
+            message_limit=120,
+            include_test_data=include_test_data,
+        )
         return {
             "thread": updated_thread,
             "user_message": user_message,
@@ -395,17 +456,25 @@ class ExperimentService:
         context_recipe_ids: list[str] | None = None,
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
+        include_test_data: bool = False,
     ) -> Iterator[dict]:
         normalized_content = content.strip()
         if not normalized_content:
             raise ExperimentValidationError("Message content cannot be empty.")
 
-        thread = self.experiment_manager.get_thread(thread_id, message_limit=40)
+        thread = self.experiment_manager.get_thread(
+            thread_id,
+            message_limit=40,
+            include_test_data=include_test_data,
+        )
         if not thread:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
 
         if context_recipe_ids is not None:
-            validated_context_ids = self._validate_recipe_ids(context_recipe_ids)
+            validated_context_ids = self._validate_recipe_ids(
+                context_recipe_ids,
+                include_test_data=include_test_data,
+            )
             self.experiment_manager.set_context_recipe_ids(
                 thread_id=thread_id,
                 context_recipe_ids=validated_context_ids,
@@ -415,6 +484,7 @@ class ExperimentService:
         attached_recipes, unresolved_recipe_names = self._resolve_attach_recipes(
             attach_recipe_ids=attach_recipe_ids,
             attach_recipe_names=attach_recipe_names,
+            include_test_data=include_test_data,
         )
         attachment_message = None
         if attached_recipes:
@@ -470,13 +540,15 @@ class ExperimentService:
             thread_id=thread_id, limit=40
         )
         thread_context_recipe_ids = self.experiment_manager.get_context_recipe_ids(
-            thread_id
+            thread_id,
+            include_test_data=include_test_data,
         )
         user_prompt = self._build_agent_user_prompt(
             mode=thread["mode"],
             user_message=normalized_content,
             context_recipe_ids=thread_context_recipe_ids,
             prior_messages=thread_messages,
+            include_test_data=include_test_data,
         )
 
         assistant_parts: list[str] = []
@@ -496,6 +568,7 @@ class ExperimentService:
                 user_message=normalized_content,
                 context_recipe_ids=thread_context_recipe_ids,
                 prior_messages=thread_messages,
+                include_test_data=include_test_data,
             )
             for fallback_chunk in self._chunk_text(fallback):
                 assistant_parts.append(fallback_chunk)
@@ -517,7 +590,11 @@ class ExperimentService:
         if not assistant_message:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
 
-        updated_thread = self.get_thread(thread_id=thread_id, message_limit=120)
+        updated_thread = self.get_thread(
+            thread_id=thread_id,
+            message_limit=120,
+            include_test_data=include_test_data,
+        )
         yield {
             "event": "final",
             "data": {

--- a/app/services/recipe_dedupe_impl.py
+++ b/app/services/recipe_dedupe_impl.py
@@ -41,7 +41,9 @@ class RecipeDedupeServiceImpl:
         ) = _get_dedupe_settings()
 
     def find_duplicate(
-        self, recipe: Recipe
+        self,
+        recipe: Recipe,
+        include_test_data: bool = False,
     ) -> tuple[bool, Optional[str], Optional[list[float]]]:
         embedding_text = RecipeEmbeddingsServiceImpl._build_title_ingredients_text(
             recipe.title, recipe.ingredients
@@ -50,6 +52,7 @@ class RecipeDedupeServiceImpl:
         nearest = self.recipe_manager.find_nearest_embedding(
             embedding=embedding,
             embedding_type=self.embedding_type,
+            include_test_data=include_test_data,
         )
         if not nearest:
             return False, None, embedding
@@ -64,7 +67,10 @@ class RecipeDedupeServiceImpl:
         if distance > self.distance_threshold:
             return False, None, embedding
 
-        existing_recipe = self.recipe_manager.get_full_recipe(nearest["recipe_id"])
+        existing_recipe = self.recipe_manager.get_full_recipe(
+            nearest["recipe_id"],
+            include_test_data=include_test_data,
+        )
         if not existing_recipe:
             return False, None, embedding
 

--- a/app/services/recipe_processing_service.py
+++ b/app/services/recipe_processing_service.py
@@ -184,7 +184,10 @@ class RecipeProcessingService:
             embedding: Optional[list[float]] = None
             if enforce_deduplication:
                 is_duplicate, existing_id, embedding = (
-                    self.dedupe_service.find_duplicate(recipe)
+                    self.dedupe_service.find_duplicate(
+                        recipe,
+                        include_test_data=is_test,
+                    )
                 )
                 if is_duplicate and existing_id:
                     logger.info(f"Duplicate recipe detected: {existing_id}")

--- a/app/tests/clients/experiments_client.py
+++ b/app/tests/clients/experiments_client.py
@@ -21,8 +21,12 @@ class ExperimentsClient(BaseAPIClient):
         mode: str = "invent_new",
         title: Optional[str] = None,
         context_recipe_ids: Optional[list[str]] = None,
+        include_test_data: bool = True,
     ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {"mode": mode}
+        payload: Dict[str, Any] = {
+            "mode": mode,
+            "include_test_data": include_test_data,
+        }
         if title is not None:
             payload["title"] = title
         if context_recipe_ids is not None:
@@ -32,9 +36,20 @@ class ExperimentsClient(BaseAPIClient):
     def list_threads(self, limit: int = 20) -> Dict[str, Any]:
         return self.get(self.THREADS_ENDPOINT, params={"limit": limit})
 
-    def get_thread(self, thread_id: str, message_limit: int = 120) -> Dict[str, Any]:
+    def get_thread(
+        self,
+        thread_id: str,
+        message_limit: int = 120,
+        include_test_data: bool = True,
+    ) -> Dict[str, Any]:
         endpoint = f"{self.THREADS_ENDPOINT}/{thread_id}"
-        return self.get(endpoint, params={"message_limit": message_limit})
+        return self.get(
+            endpoint,
+            params={
+                "message_limit": message_limit,
+                "include_test_data": include_test_data,
+            },
+        )
 
     def create_message(
         self,
@@ -42,9 +57,13 @@ class ExperimentsClient(BaseAPIClient):
         content: str,
         context_recipe_ids: Optional[list[str]] = None,
         attach_recipe_ids: Optional[list[str]] = None,
+        include_test_data: bool = True,
     ) -> Dict[str, Any]:
         endpoint = f"{self.THREADS_ENDPOINT}/{thread_id}/messages"
-        payload: Dict[str, Any] = {"content": content}
+        payload: Dict[str, Any] = {
+            "content": content,
+            "include_test_data": include_test_data,
+        }
         if context_recipe_ids is not None:
             payload["context_recipe_ids"] = context_recipe_ids
         if attach_recipe_ids is not None:
@@ -57,9 +76,13 @@ class ExperimentsClient(BaseAPIClient):
         content: str,
         context_recipe_ids: Optional[list[str]] = None,
         attach_recipe_ids: Optional[list[str]] = None,
+        include_test_data: bool = True,
     ) -> Dict[str, Any]:
         endpoint = f"{self.THREADS_ENDPOINT}/{thread_id}/messages/stream"
-        payload: Dict[str, Any] = {"content": content}
+        payload: Dict[str, Any] = {
+            "content": content,
+            "include_test_data": include_test_data,
+        }
         if context_recipe_ids is not None:
             payload["context_recipe_ids"] = context_recipe_ids
         if attach_recipe_ids is not None:

--- a/app/tests/clients/recipes_client.py
+++ b/app/tests/clients/recipes_client.py
@@ -6,8 +6,6 @@ This contains the main recipe functionality endpoints.
 """
 
 from typing import Any, Dict, Optional
-from urllib.parse import urlencode
-
 from app.core.config import settings
 
 from .base_client import BaseAPIClient
@@ -45,7 +43,11 @@ class RecipesClient(BaseAPIClient):
             payload["enforce_deduplication"] = enforce_deduplication
         return self.post(self.PROCESS_AND_STORE_ENDPOINT, json_data=payload)
 
-    def get_recipe(self, recipe_id: str) -> Dict[str, Any]:
+    def get_recipe(
+        self,
+        recipe_id: str,
+        include_test_data: bool = True,
+    ) -> Dict[str, Any]:
         """
         Get a complete recipe by its UUID.
 
@@ -53,12 +55,13 @@ class RecipesClient(BaseAPIClient):
         Router: app.api.v1.endpoints.recipes:get_recipe
         """
         endpoint = f"{settings.API_BASE_PATH}/recipes/{recipe_id}"
-        return self.get(endpoint)
+        return self.get(endpoint, params={"include_test_data": include_test_data})
 
     def list_recipes(
         self,
         limit: int = 50,
         cursor: Optional[str] = None,
+        include_test_data: bool = True,
     ) -> Dict[str, Any]:
         """
         List recipes with cursor-based pagination.
@@ -66,12 +69,10 @@ class RecipesClient(BaseAPIClient):
         Endpoint: GET /api/v1/recipes/
         Router: app.api.v1.endpoints.recipes:list_recipes
         """
-        query_params = {"limit": limit}
+        query_params = {"limit": limit, "include_test_data": include_test_data}
         if cursor is not None:
             query_params["cursor"] = cursor
-        query_string = urlencode(query_params)
-        endpoint = f"{self.LIST_RECIPES_ENDPOINT}?{query_string}"
-        return self.get(endpoint)
+        return self.get(self.LIST_RECIPES_ENDPOINT, params=query_params)
 
     def preview_recipe_from_url(self, url: str) -> Dict[str, Any]:
         """
@@ -82,7 +83,11 @@ class RecipesClient(BaseAPIClient):
         """
         return self.post(self.PREVIEW_FROM_URL_ENDPOINT, json_data={"url": url})
 
-    def get_recipe_all(self, recipe_id: str) -> Dict[str, Any]:
+    def get_recipe_all(
+        self,
+        recipe_id: str,
+        include_test_data: bool = True,
+    ) -> Dict[str, Any]:
         """
         Get a complete recipe by its UUID, including embeddings.
 
@@ -90,7 +95,7 @@ class RecipesClient(BaseAPIClient):
         Router: app.api.v1.endpoints.recipes:get_recipe_all
         """
         endpoint = f"{settings.API_BASE_PATH}/recipes/{recipe_id}/all"
-        return self.get(endpoint)
+        return self.get(endpoint, params={"include_test_data": include_test_data})
 
     def delete_recipe(self, recipe_id: str) -> Dict[str, Any]:
         """
@@ -106,6 +111,7 @@ class RecipesClient(BaseAPIClient):
         self,
         query: str,
         limit: int = 10,
+        include_test_data: bool = True,
     ) -> Dict[str, Any]:
         """
         Semantic search over recipes using vector similarity.
@@ -113,16 +119,20 @@ class RecipesClient(BaseAPIClient):
         Endpoint: GET /api/v1/recipes/search/semantic
         Router: app.api.v1.endpoints.recipes:semantic_search_recipes
         """
-        query_string = urlencode(
-            {
+        return self.get(
+            self.SEMANTIC_SEARCH_ENDPOINT,
+            params={
                 "query": query,
                 "limit": limit,
-            }
+                "include_test_data": include_test_data,
+            },
         )
-        endpoint = f"{self.SEMANTIC_SEARCH_ENDPOINT}?{query_string}"
-        return self.get(endpoint)
 
-    def create_grocery_list(self, recipe_ids: list[str]) -> Dict[str, Any]:
+    def create_grocery_list(
+        self,
+        recipe_ids: list[str],
+        include_test_data: bool = True,
+    ) -> Dict[str, Any]:
         """
         Aggregate ingredients from a set of recipe IDs into a grocery list.
 
@@ -130,4 +140,8 @@ class RecipesClient(BaseAPIClient):
         Router: app.api.v1.endpoints.recipes:create_grocery_list
         """
         payload = {"recipe_ids": recipe_ids}
-        return self.post(self.GROCERY_LIST_ENDPOINT, json_data=payload)
+        return self.post(
+            self.GROCERY_LIST_ENDPOINT,
+            json_data=payload,
+            params={"include_test_data": include_test_data},
+        )

--- a/app/tests/unit/test_experiments_endpoints.py
+++ b/app/tests/unit/test_experiments_endpoints.py
@@ -36,7 +36,9 @@ class StubExperimentService:
         mode: str,
         title: str | None = None,
         context_recipe_ids: list[str] | None = None,
+        include_test_data: bool = False,
     ) -> dict:
+        del include_test_data
         if context_recipe_ids and RECIPE_ID not in context_recipe_ids:
             raise ExperimentValidationError(
                 "One or more context recipes were not found.",
@@ -55,7 +57,13 @@ class StubExperimentService:
             "updated_at": "2026-03-16T00:00:00+00:00",
         }
 
-    def get_thread(self, thread_id: str, message_limit: int = 100) -> dict:
+    def get_thread(
+        self,
+        thread_id: str,
+        message_limit: int = 100,
+        include_test_data: bool = False,
+    ) -> dict:
+        del include_test_data
         if thread_id != THREAD_ID:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         return {
@@ -89,7 +97,9 @@ class StubExperimentService:
         context_recipe_ids: list[str] | None = None,
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
+        include_test_data: bool = False,
     ) -> dict:
+        del include_test_data
         if thread_id != THREAD_ID:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         if context_recipe_ids and RECIPE_ID not in context_recipe_ids:
@@ -135,7 +145,9 @@ class StubExperimentService:
         context_recipe_ids: list[str] | None = None,
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
+        include_test_data: bool = False,
     ):
+        del include_test_data
         if thread_id != THREAD_ID:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         yield {"event": "status", "data": {"step": "drafting"}}

--- a/app/tests/unit/test_grocery_list_endpoint.py
+++ b/app/tests/unit/test_grocery_list_endpoint.py
@@ -17,12 +17,19 @@ GROCERY_LIST_PATH = f"{settings.API_BASE_PATH}/recipes/grocery-list"
 class FakeRecipeManager:
     def __init__(self, ingredients_by_recipe: dict[str, list[str]] | None = None):
         self.ingredients_by_recipe = ingredients_by_recipe or {}
-        self.calls: list[list[str]] = []
+        self.calls: list[dict[str, object]] = []
 
     def get_ingredients_for_recipes(
-        self, recipe_ids: list[str]
+        self,
+        recipe_ids: list[str],
+        include_test_data: bool = False,
     ) -> dict[str, list[str]]:
-        self.calls.append(recipe_ids)
+        self.calls.append(
+            {
+                "recipe_ids": recipe_ids,
+                "include_test_data": include_test_data,
+            }
+        )
         return {
             recipe_id: self.ingredients_by_recipe[recipe_id]
             for recipe_id in recipe_ids
@@ -86,7 +93,9 @@ def test_create_grocery_list_returns_aggregated_ingredients() -> None:
     assert body["recipe_ids"] == [RECIPE_ONE, RECIPE_TWO]
     assert body["ingredients"] == ["2 tomatoes", "2 cloves garlic", "1 onion"]
     assert body["count"] == 3
-    assert manager.calls == [[RECIPE_ONE, RECIPE_TWO]]
+    assert manager.calls == [
+        {"recipe_ids": [RECIPE_ONE, RECIPE_TWO], "include_test_data": False}
+    ]
     assert grocery_service.calls == [
         ["1 tomato", "2 cloves garlic", "1 tomato", "1 onion"]
     ]
@@ -110,7 +119,9 @@ def test_create_grocery_list_deduplicates_recipe_ids_before_loading() -> None:
     )
 
     assert response.status_code == 200
-    assert manager.calls == [[RECIPE_ONE, RECIPE_TWO]]
+    assert manager.calls == [
+        {"recipe_ids": [RECIPE_ONE, RECIPE_TWO], "include_test_data": False}
+    ]
 
 
 def test_create_grocery_list_returns_404_when_any_recipe_is_missing() -> None:

--- a/app/tests/unit/test_recipe_process_and_store_endpoint.py
+++ b/app/tests/unit/test_recipe_process_and_store_endpoint.py
@@ -34,10 +34,16 @@ class FakeRecipeProcessingService:
 
 class FakeRecipeManager:
     def __init__(self) -> None:
-        self.calls: list[str] = []
+        self.calls: list[dict[str, object]] = []
 
-    def get_full_recipe(self, recipe_id: str) -> dict:
-        self.calls.append(recipe_id)
+    def get_full_recipe(
+        self,
+        recipe_id: str,
+        include_test_data: bool = False,
+    ) -> dict:
+        self.calls.append(
+            {"recipe_id": recipe_id, "include_test_data": include_test_data}
+        )
         return {
             "id": recipe_id,
             "title": "Tomato Pasta",
@@ -88,6 +94,9 @@ def test_process_and_store_forwards_source_url() -> None:
             "is_test": False,
         }
     ]
+    assert recipe_manager.calls == [
+        {"recipe_id": RECIPE_ID, "include_test_data": False}
+    ]
 
 
 def test_process_and_store_accepts_source_url_alias() -> None:
@@ -105,3 +114,28 @@ def test_process_and_store_accepts_source_url_alias() -> None:
 
     assert response.status_code == 200
     assert processing_service.calls[0]["source_url"] == SOURCE_URL
+
+
+def test_process_and_store_returns_test_recipe_when_requested() -> None:
+    processing_service = FakeRecipeProcessingService()
+    recipe_manager = FakeRecipeManager()
+    client = build_client(processing_service, recipe_manager)
+
+    response = client.post(
+        PROCESS_AND_STORE_PATH,
+        json={
+            "raw_input": "Tomato Pasta recipe with ingredients and instructions.",
+            "isTest": True,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["created"] is True
+    assert body["recipe_id"] == RECIPE_ID
+    assert body["recipe"]["id"] == RECIPE_ID
+    assert processing_service.calls[0]["is_test"] is True
+    assert recipe_manager.calls == [
+        {"recipe_id": RECIPE_ID, "include_test_data": True}
+    ]

--- a/app/tests/unit/test_recipe_process_and_store_endpoint.py
+++ b/app/tests/unit/test_recipe_process_and_store_endpoint.py
@@ -136,6 +136,4 @@ def test_process_and_store_returns_test_recipe_when_requested() -> None:
     assert body["recipe_id"] == RECIPE_ID
     assert body["recipe"]["id"] == RECIPE_ID
     assert processing_service.calls[0]["is_test"] is True
-    assert recipe_manager.calls == [
-        {"recipe_id": RECIPE_ID, "include_test_data": True}
-    ]
+    assert recipe_manager.calls == [{"recipe_id": RECIPE_ID, "include_test_data": True}]

--- a/app/tests/unit/test_recipe_semantic_search_endpoint.py
+++ b/app/tests/unit/test_recipe_semantic_search_endpoint.py
@@ -54,6 +54,7 @@ class FakeRecipeManager:
         embedding_type: str,
         limit: int = 10,
         max_distance: float = 0.35,
+        include_test_data: bool = False,
     ) -> list[dict]:
         self.calls.append(
             {
@@ -61,6 +62,7 @@ class FakeRecipeManager:
                 "embedding_type": embedding_type,
                 "limit": limit,
                 "max_distance": max_distance,
+                "include_test_data": include_test_data,
             }
         )
         if self.error:
@@ -71,11 +73,13 @@ class FakeRecipeManager:
         self,
         recipe_ids: list[str],
         max_ingredients: int = 8,
+        include_test_data: bool = False,
     ) -> dict[str, list[str]]:
         self.preview_calls.append(
             {
                 "recipe_ids": recipe_ids,
                 "max_ingredients": max_ingredients,
+                "include_test_data": include_test_data,
             }
         )
         return {
@@ -87,8 +91,15 @@ class FakeRecipeManager:
         self,
         title_query: str,
         limit: int = 5,
+        include_test_data: bool = False,
     ) -> list[dict]:
-        self.title_calls.append({"title_query": title_query, "limit": limit})
+        self.title_calls.append(
+            {
+                "title_query": title_query,
+                "limit": limit,
+                "include_test_data": include_test_data,
+            }
+        )
         if self.title_error:
             raise self.title_error
         return self.title_results
@@ -179,7 +190,13 @@ def test_name_search_returns_results() -> None:
             "distance": None,
         },
     ]
-    assert fake_manager.title_calls == [{"title_query": "chi", "limit": 10}]
+    assert fake_manager.title_calls == [
+        {
+            "title_query": "chi",
+            "limit": 10,
+            "include_test_data": False,
+        }
+    ]
 
 
 def test_name_search_rejects_short_queries() -> None:
@@ -271,6 +288,7 @@ def test_semantic_search_returns_results() -> None:
             "embedding_type": "title_ingredients",
             "limit": expected_limit,
             "max_distance": settings.SEMANTIC_SEARCH_MAX_DISTANCE,
+            "include_test_data": False,
         }
     ]
 
@@ -403,7 +421,11 @@ def test_semantic_search_applies_rerank_when_enabled(monkeypatch) -> None:
     assert payload["results"][1]["rerank_score"] == 0.76
     assert len(fake_reranker.calls) == 1
     assert fake_manager.preview_calls == [
-        {"recipe_ids": [recipe_one, recipe_two], "max_ingredients": 8}
+        {
+            "recipe_ids": [recipe_one, recipe_two],
+            "max_ingredients": 8,
+            "include_test_data": False,
+        }
     ]
 
 

--- a/app/tests/unit/test_recipes_list_endpoint.py
+++ b/app/tests/unit/test_recipes_list_endpoint.py
@@ -41,12 +41,14 @@ class FakeRecipeManager:
         limit: int = 50,
         cursor_created_at: datetime | None = None,
         cursor_id: str | None = None,
+        include_test_data: bool = False,
     ) -> list[dict]:
         self.calls.append(
             {
                 "limit": limit,
                 "cursor_created_at": cursor_created_at,
                 "cursor_id": cursor_id,
+                "include_test_data": include_test_data,
             }
         )
         if self.error:
@@ -84,6 +86,7 @@ def test_list_recipes_uses_default_limit() -> None:
             "limit": 51,
             "cursor_created_at": None,
             "cursor_id": None,
+            "include_test_data": False,
         }
     ]
 
@@ -115,6 +118,7 @@ def test_list_recipes_returns_next_cursor_when_more_results_exist() -> None:
             "limit": 2,
             "cursor_created_at": None,
             "cursor_id": None,
+            "include_test_data": False,
         }
     ]
 
@@ -136,6 +140,7 @@ def test_list_recipes_passes_decoded_cursor_to_manager() -> None:
             "limit": 26,
             "cursor_created_at": cursor_created_at,
             "cursor_id": RECIPE_ONE,
+            "include_test_data": False,
         }
     ]
 


### PR DESCRIPTION
This change adds an include_test_data control across experiment and recipe APIs, plus the test API clients. Data-manager and service query paths now consistently exclude test recipes by default and allow explicit opt-in where needed. Semantic search caching/rerank paths, dedupe, recipe-book counts, and grocery ingredient loading were updated to respect this behavior. Unit tests were expanded to cover the new parameters and forwarding behavior.