### PR TITLE
Improve browse resilience and reuse recipe UI building blocks

### DIFF
--- a/apps/web/src/app/books/[bookId]/page.tsx
+++ b/apps/web/src/app/books/[bookId]/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
-import { Clock3, Users2 } from "lucide-react";
 import { notFound } from "next/navigation";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
 import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
+import { RecipeMetadataBadges } from "@/components/recipe-metadata-badges";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -190,28 +190,21 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
                   {availableRecipes.map(({ id, recipe }) => (
                     <Card key={id} className="border-border/80 bg-background/80 shadow-none">
                       <CardHeader className="space-y-3">
-                        <CardTitle className="font-display text-3xl leading-tight">
+                        <CardTitle
+                          className="line-clamp-2 break-words font-display text-3xl leading-tight"
+                          title={recipe.title || "Untitled recipe"}
+                        >
                           {recipe.title || "Untitled recipe"}
                         </CardTitle>
-                        <div className="flex flex-wrap gap-2 text-sm">
-                          {recipe.total_time ? (
-                            <Badge variant="secondary" className="gap-1.5">
-                              <Clock3 className="size-3.5" />
-                              {recipe.total_time}
-                            </Badge>
-                          ) : null}
-                          {recipe.servings ? (
-                            <Badge variant="secondary" className="gap-1.5">
-                              <Users2 className="size-3.5" />
-                              {recipe.servings}
-                            </Badge>
-                          ) : null}
-                        </div>
+                        <RecipeMetadataBadges
+                          servings={recipe.servings}
+                          totalTime={recipe.total_time}
+                        />
                       </CardHeader>
                       <CardContent className="space-y-4">
-                        <p className="line-clamp-3 text-sm text-muted-foreground">
+                        <p className="line-clamp-3 break-words text-sm text-muted-foreground">
                           {recipe.ingredients.slice(0, 3).join(" • ") ||
-                            "No ingredient preview available."}
+                            "No ingredient preview is available yet."}
                         </p>
                         <Button asChild variant="outline" size="sm">
                           <Link href={`/recipes/${recipe.id}`}>Open Recipe</Link>

--- a/apps/web/src/app/browse/components/browse-results-grid.tsx
+++ b/apps/web/src/app/browse/components/browse-results-grid.tsx
@@ -1,6 +1,7 @@
-import { ArrowRight, Clock3, Users2 } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 
 import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
+import { RecipeMetadataBadges } from "@/components/recipe-metadata-badges";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -49,6 +50,7 @@ function SearchCard({
   const recipeId = result.id;
   const ingredients = recipe?.ingredients?.slice(0, 3) ?? [];
   const canOpen = Boolean(recipeId);
+  const hasRecipeMetadata = Boolean(recipe?.total_time?.trim() || recipe?.servings?.trim());
 
   return (
     <Card
@@ -70,38 +72,33 @@ function SearchCard({
       >
         <span className="sr-only">Open {title}</span>
       </Button>
-      <CardHeader className="gap-3">
-        <CardTitle className="font-display text-2xl tracking-tight">{title}</CardTitle>
 
-        <CardDescription className="flex min-h-6 flex-wrap items-center gap-2 text-sm">
+      <CardHeader className="gap-3">
+        <CardTitle
+          className="line-clamp-2 break-words font-display text-2xl tracking-tight"
+          title={title}
+        >
+          {title}
+        </CardTitle>
+
+        <CardDescription className="flex min-h-6 min-w-0 flex-wrap items-center gap-2 text-sm">
           {result.matchSource === "semantic" ? (
             <Badge variant="secondary">Related recipe</Badge>
           ) : null}
+
           {recipe ? (
-            <>
-              {recipe.total_time ? (
-                <Badge variant="outline" className="gap-1.5">
-                  <Clock3 className="size-3" />
-                  {recipe.total_time}
-                </Badge>
-              ) : null}
-              {recipe.servings ? (
-                <Badge variant="outline" className="gap-1.5">
-                  <Users2 className="size-3" />
-                  {recipe.servings}
-                </Badge>
-              ) : null}
-              {!recipe.total_time && !recipe.servings ? (
-                <span className="text-muted-foreground">Metadata available</span>
-              ) : null}
-            </>
+            hasRecipeMetadata ? (
+              <RecipeMetadataBadges servings={recipe.servings} totalTime={recipe.total_time} />
+            ) : (
+              <span className="text-muted-foreground">No time or serving info yet.</span>
+            )
           ) : isDetailsLoading ? (
             <>
               <Skeleton className="h-6 w-20 rounded-full bg-muted/85" />
               <Skeleton className="h-6 w-16 rounded-full bg-muted/85" />
             </>
           ) : (
-            <span className="text-muted-foreground">Metadata unavailable</span>
+            <span className="text-muted-foreground">Recipe metadata is temporarily unavailable.</span>
           )}
         </CardDescription>
       </CardHeader>
@@ -117,7 +114,7 @@ function SearchCard({
               {ingredients.map((ingredient) => (
                 <li
                   key={`${result.id}-${ingredient}`}
-                  className="truncate text-sm text-foreground/85"
+                  className="line-clamp-1 break-words text-sm text-foreground/85"
                   title={ingredient}
                 >
                   • {ingredient}
@@ -126,7 +123,7 @@ function SearchCard({
             </ul>
           ) : (
             <p className="text-sm text-muted-foreground">
-              No ingredient preview available. Open the recipe for full details.
+              Ingredient preview is not available for this recipe yet.
             </p>
           )
         ) : isDetailsLoading ? (
@@ -137,7 +134,7 @@ function SearchCard({
           </div>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Preview unavailable right now. Open the recipe for full details.
+            Preview is temporarily unavailable. Open the recipe for full details.
           </p>
         )}
 
@@ -154,7 +151,7 @@ function SearchCard({
             />
           ) : null}
           <div className="inline-flex items-center gap-1.5 text-sm font-medium text-primary">
-            Open recipe
+            {canOpen ? "Open recipe" : "Recipe unavailable"}
             <ArrowRight className="size-4" />
           </div>
         </div>
@@ -179,6 +176,7 @@ type BrowseResultsGridProps = {
   recipeLoadingById: Record<string, boolean>;
   onLoadRelated: () => void;
   onLoadMore: () => void;
+  onRetrySearch: () => void;
   onCardOpen: (recipeId: string) => void;
 };
 
@@ -198,12 +196,13 @@ export function BrowseResultsGrid({
   recipeLoadingById,
   onLoadRelated,
   onLoadMore,
+  onRetrySearch,
   onCardOpen,
 }: BrowseResultsGridProps) {
   const isQueryMode = Boolean(queryFromUrl);
 
   return (
-    <section className="space-y-5 ff-animate-enter-delayed">
+    <section className="space-y-6 ff-animate-enter-delayed">
       <h2 className="font-display text-[clamp(1.8rem,3vw,2.4rem)] tracking-tight">
         {queryFromUrl ? `Results for "${queryFromUrl}"` : "Browse Recipes"}
       </h2>
@@ -214,6 +213,11 @@ export function BrowseResultsGrid({
             <CardTitle>Search Error</CardTitle>
             <CardDescription>{searchError}</CardDescription>
           </CardHeader>
+          <CardContent>
+            <Button type="button" variant="outline" size="sm" onClick={onRetrySearch}>
+              Try search again
+            </Button>
+          </CardContent>
         </Card>
       ) : null}
 
@@ -229,7 +233,7 @@ export function BrowseResultsGrid({
       ) : null}
 
       {showLoadingGrid ? (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(18rem,1fr))]">
           <ResultCardLoading />
           <ResultCardLoading />
           <ResultCardLoading />
@@ -244,7 +248,9 @@ export function BrowseResultsGrid({
           <CardHeader>
             <CardTitle>No recipes found</CardTitle>
             <CardDescription>
-              Try different keywords or a broader phrase.
+              {isQueryMode
+                ? `No recipes matched "${queryFromUrl}". Try a broader phrase or fewer keywords.`
+                : "No recipes are available yet. Add your first recipe to get started."}
             </CardDescription>
           </CardHeader>
         </Card>
@@ -252,7 +258,7 @@ export function BrowseResultsGrid({
 
       {results.length ? (
         <>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-4 [grid-template-columns:repeat(auto-fit,minmax(18rem,1fr))]">
             {results.map((result) => {
               const recipeId = result.id ?? "";
               const recipe = recipeId ? recipeById[recipeId] : undefined;
@@ -281,7 +287,7 @@ export function BrowseResultsGrid({
                 onClick={onLoadMore}
                 disabled={isLoadingMore}
               >
-                {isLoadingMore ? "Loading..." : "Load more recipes"}
+                {isLoadingMore ? "Loading more..." : "Load more recipes"}
               </Button>
             </div>
           ) : null}
@@ -296,7 +302,7 @@ export function BrowseResultsGrid({
               <CardDescription>
                 {isLoadingRelated
                   ? "Finding related recipes in the background..."
-                  : `${relatedResultCount} related recipes are ready to load.`}
+                  : `${relatedResultCount} related recipes are ready to add.`}
               </CardDescription>
             </div>
             {showLoadRelated ? (

--- a/apps/web/src/app/browse/components/browse-search-form.tsx
+++ b/apps/web/src/app/browse/components/browse-search-form.tsx
@@ -3,6 +3,8 @@ import { FormEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 type BrowseSearchFormProps = {
   queryInput: string;
@@ -17,34 +19,60 @@ export function BrowseSearchForm({
   onQueryInputChange,
   onSearchSubmit,
 }: BrowseSearchFormProps) {
+  const normalizedQuery = queryInput.trim();
+  const isShortQuery = normalizedQuery.length > 0 && normalizedQuery.length < 2;
+
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     onSearchSubmit();
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-3 sm:flex-row">
-      <div className="relative flex-1">
-        <Search className="pointer-events-none absolute top-1/2 left-3.5 size-5 -translate-y-1/2 text-muted-foreground/80" />
-        <Input
-          type="search"
-          name="q"
-          value={queryInput}
-          onChange={(event) => {
-            onQueryInputChange(event.target.value);
-          }}
-          placeholder="Search recipes... e.g. 'creamy pasta' or 'quick breakfast'"
-          className="h-14 rounded-2xl border-border/85 bg-background/85 pl-11 text-base"
-        />
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <Label htmlFor="browse-search-input" className="sr-only">
+        Search recipes
+      </Label>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute top-1/2 left-3.5 size-5 -translate-y-1/2 text-muted-foreground/80" />
+          <Input
+            id="browse-search-input"
+            type="search"
+            name="q"
+            value={queryInput}
+            onChange={(event) => {
+              onQueryInputChange(event.target.value);
+            }}
+            placeholder="Search by dish, ingredient, cuisine, or dietary goal"
+            autoComplete="off"
+            aria-describedby="browse-search-hint"
+            aria-invalid={isShortQuery}
+            className="h-14 rounded-2xl border-border/85 bg-background/85 pl-11 text-base"
+          />
+        </div>
+
+        <Button
+          type="submit"
+          size="lg"
+          className="h-14 rounded-2xl px-8 text-base sm:text-lg"
+          disabled={isSearching}
+        >
+          {isSearching ? "Searching..." : "Search"}
+        </Button>
       </div>
-      <Button
-        type="submit"
-        size="lg"
-        className="h-14 rounded-2xl px-8 text-base sm:text-lg"
-        disabled={isSearching}
+
+      <p
+        id="browse-search-hint"
+        className={cn(
+          "text-sm",
+          isShortQuery ? "text-destructive" : "text-muted-foreground",
+        )}
       >
-        Search
-      </Button>
+        {isShortQuery
+          ? "Use at least 2 characters for best matches."
+          : "Search titles first, then add related semantic matches when available."}
+      </p>
     </form>
   );
 }

--- a/apps/web/src/app/browse/components/recipe-modal.tsx
+++ b/apps/web/src/app/browse/components/recipe-modal.tsx
@@ -1,8 +1,9 @@
-import { Clock3, ExternalLink, Users2, X } from "lucide-react";
+import { ExternalLink, X } from "lucide-react";
 import Link from "next/link";
 
 import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
-import { Badge } from "@/components/ui/badge";
+import { RecipeContentColumns } from "@/components/recipe-content-columns";
+import { RecipeMetadataBadges } from "@/components/recipe-metadata-badges";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -14,6 +15,7 @@ type RecipeModalProps = {
   recipe: RecipeRecord | null;
   isLoading: boolean;
   error: string | null;
+  onRetry?: () => void;
   onClose: () => void;
 };
 
@@ -22,6 +24,7 @@ export function RecipeModal({
   recipe,
   isLoading,
   error,
+  onRetry,
   onClose,
 }: RecipeModalProps) {
   const title = recipe?.title || "Recipe";
@@ -43,9 +46,12 @@ export function RecipeModal({
         <DialogTitle className="sr-only">{title}</DialogTitle>
 
         <div className="flex items-start justify-between gap-4 border-b border-border/70 bg-card/45 px-6 py-5">
-          <div className="space-y-2">
+          <div className="min-w-0 space-y-2">
             {recipe ? (
-              <h3 className="font-display text-4xl leading-tight tracking-tight text-primary sm:text-5xl">
+              <h3
+                className="break-words font-display text-4xl leading-tight tracking-tight text-primary sm:text-5xl"
+                title={title}
+              >
                 {title}
               </h3>
             ) : isLoading ? (
@@ -57,20 +63,7 @@ export function RecipeModal({
             )}
 
             {recipe ? (
-              <div className="flex flex-wrap gap-2">
-                {recipe.total_time ? (
-                  <Badge variant="secondary" className="gap-1.5">
-                    <Clock3 className="size-3.5" />
-                    {recipe.total_time}
-                  </Badge>
-                ) : null}
-                {recipe.servings ? (
-                  <Badge variant="secondary" className="gap-1.5">
-                    <Users2 className="size-3.5" />
-                    {recipe.servings}
-                  </Badge>
-                ) : null}
-              </div>
+              <RecipeMetadataBadges servings={recipe.servings} totalTime={recipe.total_time} />
             ) : null}
           </div>
 
@@ -86,12 +79,15 @@ export function RecipeModal({
                 size="sm"
               />
             ) : null}
-            <Button asChild variant="outline" size="sm">
-              <Link href={`/recipes/${recipeId}`}>
-                Open Full Page
-                <ExternalLink className="size-4" />
-              </Link>
-            </Button>
+
+            {recipeId ? (
+              <Button asChild variant="outline" size="sm">
+                <Link href={`/recipes/${recipeId}`}>
+                  Open Full Page
+                  <ExternalLink className="size-4" />
+                </Link>
+              </Button>
+            ) : null}
 
             <Button
               type="button"
@@ -113,6 +109,13 @@ export function RecipeModal({
                 <CardTitle>Unable to load recipe</CardTitle>
                 <CardDescription>{error}</CardDescription>
               </CardHeader>
+              {onRetry ? (
+                <CardContent>
+                  <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                    Try loading again
+                  </Button>
+                </CardContent>
+              ) : null}
             </Card>
           ) : null}
 
@@ -147,48 +150,10 @@ export function RecipeModal({
           ) : null}
 
           {recipe ? (
-            <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_1.3fr]">
-              <Card className="border-border/80 bg-background/80 shadow-none">
-                <CardHeader>
-                  <CardTitle className="font-display text-3xl">Ingredients</CardTitle>
-                  <CardDescription>
-                    {recipe.ingredients.length} item
-                    {recipe.ingredients.length === 1 ? "" : "s"}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-2">
-                    {recipe.ingredients.map((ingredient, index) => (
-                      <li key={`${ingredient}-${index}`} className="text-foreground/90">
-                        • {ingredient}
-                      </li>
-                    ))}
-                  </ul>
-                </CardContent>
-              </Card>
-
-              <Card className="border-border/80 bg-background/80 shadow-none">
-                <CardHeader>
-                  <CardTitle className="font-display text-3xl">Instructions</CardTitle>
-                  <CardDescription>
-                    {recipe.instructions.length} step
-                    {recipe.instructions.length === 1 ? "" : "s"}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <ol className="space-y-3">
-                    {recipe.instructions.map((instruction, index) => (
-                      <li key={`${instruction}-${index}`} className="flex items-start gap-3">
-                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
-                          {index + 1}
-                        </span>
-                        <p className="pt-0.5 text-foreground/90">{instruction}</p>
-                      </li>
-                    ))}
-                  </ol>
-                </CardContent>
-              </Card>
-            </div>
+            <RecipeContentColumns
+              ingredients={recipe.ingredients}
+              instructions={recipe.instructions}
+            />
           ) : null}
         </div>
       </DialogContent>

--- a/apps/web/src/app/browse/page.tsx
+++ b/apps/web/src/app/browse/page.tsx
@@ -30,6 +30,8 @@ export default function BrowsePage() {
     showNoResults,
     showLoadMore,
     isLoadingMore,
+    retrySearch,
+    retrySelectedRecipe,
     handleSearchSubmit,
     handleQueryInputChange,
     handleLoadRelated,
@@ -49,7 +51,7 @@ export default function BrowsePage() {
           <PageHero
             badge="Browse Recipes"
             title="Find anything instantly"
-            description="Browse your latest recipes or search by dish, ingredient, or cuisine."
+            description="Search by dish, ingredient, cuisine, or dietary goal, then pull in related semantic matches when needed."
             contentClassName="max-w-4xl"
           >
             <BrowseSearchForm
@@ -76,6 +78,7 @@ export default function BrowsePage() {
             recipeById={recipeById}
             recipeLoadingById={recipeLoadingById}
             onLoadMore={handleLoadMore}
+            onRetrySearch={retrySearch}
             onCardOpen={openRecipeModal}
           />
         </PageMain>
@@ -87,6 +90,7 @@ export default function BrowsePage() {
           recipe={selectedRecipe}
           isLoading={selectedRecipeLoading && !selectedRecipe}
           error={selectedRecipeError}
+          onRetry={retrySelectedRecipe}
           onClose={closeRecipeModal}
         />
       ) : null}

--- a/apps/web/src/app/browse/use-browse-data.ts
+++ b/apps/web/src/app/browse/use-browse-data.ts
@@ -138,9 +138,12 @@ export function useBrowseData() {
   const recipeCacheRef = useRef<Record<string, RecipeRecord>>({});
   const inFlightRecipeRef = useRef<Record<string, Promise<RecipeRecord>>>({});
   const searchRequestIdRef = useRef(0);
+  const retrySelectedRecipeRequestIdRef = useRef(0);
+  const activeRecipeIdRef = useRef(recipeIdFromUrl);
   const isBrowseModeRef = useRef(!queryFromUrl);
 
   isBrowseModeRef.current = !queryFromUrl;
+  activeRecipeIdRef.current = recipeIdFromUrl;
 
   const setBrowseUrl = useCallback(
     (nextQuery: string, nextRecipeId?: string, navigation: NavigationMode = "push") => {
@@ -464,6 +467,11 @@ export function useBrowseData() {
     };
   }, [recipeIdFromUrl, loadRecipeDetails]);
 
+  useEffect(() => {
+    // Invalidate pending retry callbacks whenever the selected modal recipe changes.
+    retrySelectedRecipeRequestIdRef.current += 1;
+  }, [recipeIdFromUrl]);
+
   const selectedRecipe = useMemo(() => {
     if (!recipeIdFromUrl) {
       return null;
@@ -480,6 +488,51 @@ export function useBrowseData() {
   const showNoResults =
     !searchError && !isSearching && !results.length && !isLoadingRelated && !showLoadRelated;
   const showLoadMore = !hasQuery && !searchError && results.length > 0 && defaultListHasMore;
+  const retrySearch = useCallback(() => {
+    void runSearch(queryFromUrl);
+  }, [queryFromUrl, runSearch]);
+
+  const retrySelectedRecipe = useCallback(() => {
+    if (!recipeIdFromUrl) {
+      return;
+    }
+
+    const requestId = retrySelectedRecipeRequestIdRef.current + 1;
+    retrySelectedRecipeRequestIdRef.current = requestId;
+    const targetRecipeId = recipeIdFromUrl;
+
+    setSelectedRecipeLoading(true);
+    setSelectedRecipeError(null);
+
+    void loadRecipeDetails(targetRecipeId)
+      .then(() => {
+        if (
+          retrySelectedRecipeRequestIdRef.current !== requestId ||
+          activeRecipeIdRef.current !== targetRecipeId
+        ) {
+          return;
+        }
+        setSelectedRecipeError(null);
+      })
+      .catch((error) => {
+        if (
+          retrySelectedRecipeRequestIdRef.current !== requestId ||
+          activeRecipeIdRef.current !== targetRecipeId
+        ) {
+          return;
+        }
+        setSelectedRecipeError(getErrorMessage(error, "Failed to load recipe details."));
+      })
+      .finally(() => {
+        if (
+          retrySelectedRecipeRequestIdRef.current !== requestId ||
+          activeRecipeIdRef.current !== targetRecipeId
+        ) {
+          return;
+        }
+        setSelectedRecipeLoading(false);
+      });
+  }, [recipeIdFromUrl, loadRecipeDetails]);
 
   function handleSearchSubmit() {
     const normalizedQuery = queryInput.trim();
@@ -577,6 +630,8 @@ export function useBrowseData() {
     showNoResults,
     showLoadMore,
     isLoadingMore,
+    retrySearch,
+    retrySelectedRecipe,
     handleSearchSubmit,
     handleQueryInputChange,
     handleLoadRelated,

--- a/apps/web/src/app/recipes/[recipeId]/page.tsx
+++ b/apps/web/src/app/recipes/[recipeId]/page.tsx
@@ -1,4 +1,3 @@
-import { Clock3, LinkIcon, Users2 } from "lucide-react";
 import { notFound } from "next/navigation";
 
 import { DeleteRecipeButton } from "@/components/delete-recipe-button";
@@ -6,8 +5,9 @@ import { ForkfolioHeader } from "@/components/forkfolio-header";
 import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
 import { RecipeBagToggleButton } from "@/components/recipe-bag-toggle-button";
 import { RecipeBookMembership } from "@/components/recipe-book-membership";
+import { RecipeContentColumns } from "@/components/recipe-content-columns";
+import { RecipeMetadataBadges } from "@/components/recipe-metadata-badges";
 import { TrackRecipeHistory } from "@/components/track-recipe-history";
-import { Badge } from "@/components/ui/badge";
 import {
   Card,
   CardContent,
@@ -25,78 +25,6 @@ import {
 type RecipePageProps = {
   params: Promise<{ recipeId: string }>;
 };
-
-function MetadataBadges({ recipe }: { recipe: RecipeRecord }) {
-  return (
-    <div className="flex flex-wrap gap-2">
-      {recipe.total_time ? (
-        <Badge variant="secondary" className="gap-1.5">
-          <Clock3 className="size-3.5" />
-          {recipe.total_time}
-        </Badge>
-      ) : null}
-      {recipe.servings ? (
-        <Badge variant="secondary" className="gap-1.5">
-          <Users2 className="size-3.5" />
-          {recipe.servings}
-        </Badge>
-      ) : null}
-      {recipe.source_url ? (
-        <Badge variant="outline" className="max-w-full gap-1.5 truncate">
-          <LinkIcon className="size-3.5" />
-          <span className="truncate">{recipe.source_url}</span>
-        </Badge>
-      ) : null}
-    </div>
-  );
-}
-
-function RecipeBody({ recipe }: { recipe: RecipeRecord }) {
-  return (
-    <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_1.3fr]">
-      <Card className="border-border/80 bg-background/80 shadow-none">
-        <CardHeader>
-          <CardTitle className="font-display text-3xl">Ingredients</CardTitle>
-          <CardDescription>
-            {recipe.ingredients.length} item
-            {recipe.ingredients.length === 1 ? "" : "s"}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-2">
-            {recipe.ingredients.map((ingredient, index) => (
-              <li key={`${ingredient}-${index}`} className="text-foreground/90">
-                • {ingredient}
-              </li>
-            ))}
-          </ul>
-        </CardContent>
-      </Card>
-
-      <Card className="border-border/80 bg-background/80 shadow-none">
-        <CardHeader>
-          <CardTitle className="font-display text-3xl">Instructions</CardTitle>
-          <CardDescription>
-            {recipe.instructions.length} step
-            {recipe.instructions.length === 1 ? "" : "s"}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ol className="space-y-3">
-            {recipe.instructions.map((instruction, index) => (
-              <li key={`${instruction}-${index}`} className="flex items-start gap-3">
-                <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
-                  {index + 1}
-                </span>
-                <p className="pt-0.5 text-foreground/90">{instruction}</p>
-              </li>
-            ))}
-          </ol>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
 
 export default async function RecipeDetailPage({ params }: RecipePageProps) {
   const { recipeId } = await params;
@@ -151,11 +79,16 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
           title={recipe.title || "Untitled recipe"}
           contentClassName="max-w-5xl"
         >
-          <MetadataBadges recipe={recipe} />
+          <RecipeMetadataBadges
+            servings={recipe.servings}
+            totalTime={recipe.total_time}
+            sourceUrl={recipe.source_url}
+            showSourceUrl
+          />
 
           <Card className="border-border/80 bg-background/82 shadow-none">
             <CardContent className="space-y-5 pt-6 text-sm text-muted-foreground">
-              <div className="flex flex-wrap gap-x-5 gap-y-1">
+              <div className="flex flex-wrap gap-x-5 gap-y-1 break-words">
                 {recipe.created_at ? <span>Created: {recipe.created_at}</span> : null}
                 {recipe.updated_at ? <span>Updated: {recipe.updated_at}</span> : null}
               </div>
@@ -184,7 +117,10 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
           <RecipeBookMembership recipeId={recipe.id} />
         </section>
 
-        <RecipeBody recipe={recipe} />
+        <RecipeContentColumns
+          ingredients={recipe.ingredients}
+          instructions={recipe.instructions}
+        />
       </PageMain>
     </PageShell>
   );

--- a/apps/web/src/components/recipe-content-columns.tsx
+++ b/apps/web/src/components/recipe-content-columns.tsx
@@ -1,0 +1,80 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type RecipeContentColumnsProps = {
+  ingredients: string[];
+  instructions: string[];
+  className?: string;
+  cardClassName?: string;
+};
+
+function cleanLines(lines: string[]): string[] {
+  return lines
+    .map((line) => line.trim())
+    .filter((line) => Boolean(line));
+}
+
+export function RecipeContentColumns({
+  ingredients,
+  instructions,
+  className,
+  cardClassName,
+}: RecipeContentColumnsProps) {
+  const ingredientLines = cleanLines(ingredients);
+  const instructionLines = cleanLines(instructions);
+
+  return (
+    <div className={cn("grid grid-cols-1 gap-5 lg:grid-cols-[1fr_1.3fr]", className)}>
+      <Card className={cn("border-border/80 bg-background/80 shadow-none", cardClassName)}>
+        <CardHeader>
+          <CardTitle className="font-display text-3xl">Ingredients</CardTitle>
+          <CardDescription>
+            {ingredientLines.length} item{ingredientLines.length === 1 ? "" : "s"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {ingredientLines.length ? (
+            <ul className="space-y-2">
+              {ingredientLines.map((ingredient, index) => (
+                <li key={`${ingredient}-${index}`} className="break-words text-foreground/90">
+                  • {ingredient}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No ingredients are listed for this recipe yet.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className={cn("border-border/80 bg-background/80 shadow-none", cardClassName)}>
+        <CardHeader>
+          <CardTitle className="font-display text-3xl">Instructions</CardTitle>
+          <CardDescription>
+            {instructionLines.length} step{instructionLines.length === 1 ? "" : "s"}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {instructionLines.length ? (
+            <ol className="space-y-3">
+              {instructionLines.map((instruction, index) => (
+                <li key={`${instruction}-${index}`} className="flex items-start gap-3">
+                  <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+                    {index + 1}
+                  </span>
+                  <p className="break-words pt-0.5 text-foreground/90">{instruction}</p>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              No instructions are listed for this recipe yet.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/recipe-metadata-badges.tsx
+++ b/apps/web/src/components/recipe-metadata-badges.tsx
@@ -1,0 +1,65 @@
+import { Clock3, LinkIcon, Users2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type RecipeMetadataBadgesProps = {
+  servings?: string | null;
+  totalTime?: string | null;
+  sourceUrl?: string | null;
+  showSourceUrl?: boolean;
+  className?: string;
+};
+
+function normalizeText(value: string | null | undefined): string {
+  return value?.trim() ?? "";
+}
+
+export function RecipeMetadataBadges({
+  servings,
+  totalTime,
+  sourceUrl,
+  showSourceUrl = false,
+  className,
+}: RecipeMetadataBadgesProps) {
+  const normalizedServings = normalizeText(servings);
+  const normalizedTotalTime = normalizeText(totalTime);
+  const normalizedSourceUrl = normalizeText(sourceUrl);
+  const showAnyBadge =
+    Boolean(normalizedServings) ||
+    Boolean(normalizedTotalTime) ||
+    (showSourceUrl && Boolean(normalizedSourceUrl));
+
+  if (!showAnyBadge) {
+    return null;
+  }
+
+  return (
+    <div className={cn("flex min-w-0 flex-wrap gap-2", className)}>
+      {normalizedTotalTime ? (
+        <Badge variant="secondary" className="min-w-0 max-w-full gap-1.5">
+          <Clock3 className="size-3.5 shrink-0" />
+          <span className="truncate">{normalizedTotalTime}</span>
+        </Badge>
+      ) : null}
+
+      {normalizedServings ? (
+        <Badge variant="secondary" className="min-w-0 max-w-full gap-1.5">
+          <Users2 className="size-3.5 shrink-0" />
+          <span className="truncate">{normalizedServings}</span>
+        </Badge>
+      ) : null}
+
+      {showSourceUrl && normalizedSourceUrl ? (
+        <Badge
+          variant="outline"
+          className="min-w-0 max-w-full gap-1.5 overflow-hidden"
+          title={normalizedSourceUrl}
+        >
+          <LinkIcon className="size-3.5 shrink-0" />
+          <span className="truncate">{normalizedSourceUrl}</span>
+        </Badge>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
This PR extracts reusable `RecipeMetadataBadges` and `RecipeContentColumns` components and adopts them across browse, recipe detail, and recipe book views to remove duplicated rendering logic. It refreshes browse card and search form copy/layout behavior for long text and metadata states, including responsive grid updates and clearer empty/loading messaging. It adds explicit retry actions for search failures and modal recipe-load failures, plus request-guarded retry handling in `useBrowseData` to prevent stale async state updates. Validation: `npm run build`, `npm run lint -- <touched files>`, and `npm run test`.