### PR TITLE
Add Braintrust LLM tracing with request/thread boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Backend (optional behavior controls):
 
 - `RECIPE_UNIT_SYSTEM` (`us`, `metric`, or `both`; default from `config/app.config.ini`)
 - `SEARCH_KEYWORDS_FILE` (path to search heuristic keyword JSON; defaults to `config/search_keywords.json`)
+- `BRAINTRUST_PROJECT_ID` (Braintrust project ID override; defaults to config `observability.braintrust_project_id`)
+- `BRAINTRUST_APP_URL` (Braintrust app URL override; defaults to config `observability.braintrust_app_url`)
+- `BRAINTRUST_API_KEY` (required when Braintrust tracing is enabled)
 
 Frontend runtime vars:
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -86,6 +86,34 @@ class Settings:
             "api", "semantic_search_heuristics_enabled", fallback=True
         )
 
+        # Observability
+        self.BRAINTRUST_TRACING_ENABLED = self._cfg.getboolean(
+            "observability",
+            "braintrust_enabled",
+            fallback=False,
+        )
+        configured_project_id = self._cfg.get(
+            "observability",
+            "braintrust_project_id",
+            fallback=self._cfg.get(
+                "observability",
+                "braintrust_project",
+                fallback="4e61341a-cc9a-4ce4-a107-4f9980e76b1a",
+            ),
+        )
+        self.BRAINTRUST_PROJECT_ID: str = os.getenv(
+            "BRAINTRUST_PROJECT_ID",
+            configured_project_id,
+        ).strip()
+        self.BRAINTRUST_APP_URL: str = os.getenv(
+            "BRAINTRUST_APP_URL",
+            self._cfg.get(
+                "observability",
+                "braintrust_app_url",
+                fallback="https://www.braintrust.dev",
+            ),
+        ).strip()
+
         # DB settings
         self.DB_HOST: str = self._cfg.get("database", "host")
         self.DB_PORT: int = self._cfg.getint("database", "port", fallback=5432)
@@ -160,6 +188,7 @@ class Settings:
         # Secrets: environment-only.
         self.OPEN_ROUTER_API_KEY: str = os.getenv("OPEN_ROUTER_API_KEY", "").strip()
         self.SUPABASE_PASSWORD: str = os.getenv("SUPABASE_PASSWORD", "").strip()
+        self.BRAINTRUST_API_KEY: str = os.getenv("BRAINTRUST_API_KEY", "").strip()
 
     @staticmethod
     def _load_config(config_path: Path) -> configparser.ConfigParser:

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import Iterable
 from collections import deque
 from typing import Deque
+from uuid import UUID
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
@@ -16,9 +17,62 @@ from starlette.status import (
     HTTP_504_GATEWAY_TIMEOUT,
 )
 
+from app.core.tracing import (
+    bind_trace_context,
+    create_request_trace_id,
+    reset_trace_context,
+)
+
 HTTP_413_REQUEST_TOO_LARGE = getattr(
     status, "HTTP_413_CONTENT_TOO_LARGE", status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 )
+
+
+class TraceContextMiddleware:
+    def __init__(self, app, api_base_path: str = "/api/v1") -> None:
+        self.app = app
+        normalized_base_path = _normalize_path(api_base_path)
+        self._experiment_thread_prefix = f"{normalized_base_path}/experiments/threads/"
+
+    def _resolve_trace(self, request_path: str) -> tuple[str, str]:
+        thread_trace_id = self._extract_experiment_thread_id(request_path)
+        if thread_trace_id:
+            return thread_trace_id, "thread"
+        return create_request_trace_id(), "request"
+
+    def _extract_experiment_thread_id(self, request_path: str) -> str | None:
+        if not request_path.startswith(self._experiment_thread_prefix):
+            return None
+
+        suffix = request_path[len(self._experiment_thread_prefix) :]
+        candidate = suffix.split("/", maxsplit=1)[0].strip()
+        if not candidate:
+            return None
+
+        try:
+            return str(UUID(candidate))
+        except ValueError:
+            return None
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_path = str(scope.get("path") or "/")
+        request_method = str(scope.get("method") or "GET").upper()
+        trace_id, trace_source = self._resolve_trace(request_path)
+
+        tokens = bind_trace_context(
+            trace_id=trace_id,
+            source=trace_source,
+            request_method=request_method,
+            request_path=request_path,
+        )
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            reset_trace_context(tokens)
 
 
 class AuthTokenMiddleware(BaseHTTPMiddleware):

--- a/app/core/tracing.py
+++ b/app/core/tracing.py
@@ -117,14 +117,21 @@ def setup_braintrust() -> None:
         logger.warning("Braintrust tracing enabled but no project ID is configured.")
         return
 
+    api_key = settings.BRAINTRUST_API_KEY.strip()
+    if not api_key:
+        logger.warning(
+            "Braintrust tracing enabled but BRAINTRUST_API_KEY is missing. "
+            "Tracing will remain disabled."
+        )
+        return
+
     init_kwargs: dict[str, Any] = {
         "project_id": project_id,
         "set_current": True,
+        "api_key": api_key,
     }
     if settings.BRAINTRUST_APP_URL:
         init_kwargs["app_url"] = settings.BRAINTRUST_APP_URL
-    if settings.BRAINTRUST_API_KEY:
-        init_kwargs["api_key"] = settings.BRAINTRUST_API_KEY
 
     try:
         _braintrust_init_logger(**init_kwargs)
@@ -166,21 +173,35 @@ def start_trace_span(
     if span_type:
         span_kwargs["type"] = span_type
 
-    resolved_trace_id = root_trace_id or current_trace_id()
     span_depth = _SPAN_DEPTH.get()
     parent_export = _ACTIVE_PARENT_EXPORT.get()
     if parent_export:
         span_kwargs["parent"] = parent_export
-    elif resolved_trace_id and span_depth == 0:
-        span_kwargs["root_span_id"] = resolved_trace_id
+    elif root_trace_id and span_depth == 0:
+        span_kwargs["root_span_id"] = root_trace_id
 
     event_kwargs: dict[str, Any] = {}
     if input_data is not None:
         event_kwargs["input"] = input_data
     if output_data is not None:
         event_kwargs["output"] = output_data
-    if metadata:
-        event_kwargs["metadata"] = metadata
+
+    resolved_metadata = dict(metadata or {})
+    trace_id = current_trace_id()
+    if trace_id:
+        resolved_metadata.setdefault("request_trace_id", trace_id)
+    request_method = current_request_method()
+    if request_method:
+        resolved_metadata.setdefault("request_method", request_method)
+    request_path = current_request_path()
+    if request_path:
+        resolved_metadata.setdefault("request_path", request_path)
+    trace_source = current_trace_source()
+    if trace_source:
+        resolved_metadata.setdefault("trace_source", trace_source)
+    if resolved_metadata:
+        event_kwargs["metadata"] = resolved_metadata
+
     if metrics:
         event_kwargs["metrics"] = metrics
 

--- a/app/core/tracing.py
+++ b/app/core/tracing.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+try:
+    from braintrust import flush as _braintrust_flush
+    from braintrust import init_logger as _braintrust_init_logger
+    from braintrust import start_span as _braintrust_start_span
+except ImportError:
+    _braintrust_flush = None
+    _braintrust_init_logger = None
+    _braintrust_start_span = None
+
+_TRACE_ID: ContextVar[str | None] = ContextVar("forkfolio_trace_id", default=None)
+_TRACE_SOURCE: ContextVar[str] = ContextVar("forkfolio_trace_source", default="request")
+_REQUEST_METHOD: ContextVar[str | None] = ContextVar(
+    "forkfolio_trace_request_method", default=None
+)
+_REQUEST_PATH: ContextVar[str | None] = ContextVar(
+    "forkfolio_trace_request_path", default=None
+)
+_SPAN_DEPTH: ContextVar[int] = ContextVar("forkfolio_trace_span_depth", default=0)
+_ACTIVE_PARENT_EXPORT: ContextVar[str | None] = ContextVar(
+    "forkfolio_trace_active_parent_export", default=None
+)
+
+_BRAINTRUST_ENABLED = False
+_BRAINTRUST_INITIALIZED = False
+
+
+@dataclass(frozen=True)
+class TraceContextTokens:
+    trace_id_token: Token[str | None]
+    trace_source_token: Token[str]
+    request_method_token: Token[str | None]
+    request_path_token: Token[str | None]
+
+
+def _safe_reset(var: ContextVar[Any], token: Token[Any], fallback: Any) -> None:
+    try:
+        var.reset(token)
+    except ValueError:
+        var.set(fallback)
+
+
+def create_request_trace_id() -> str:
+    return str(uuid4())
+
+
+def bind_trace_context(
+    trace_id: str,
+    source: str,
+    request_method: str,
+    request_path: str,
+) -> TraceContextTokens:
+    return TraceContextTokens(
+        trace_id_token=_TRACE_ID.set(trace_id),
+        trace_source_token=_TRACE_SOURCE.set(source),
+        request_method_token=_REQUEST_METHOD.set(request_method),
+        request_path_token=_REQUEST_PATH.set(request_path),
+    )
+
+
+def reset_trace_context(tokens: TraceContextTokens) -> None:
+    _safe_reset(_TRACE_ID, tokens.trace_id_token, None)
+    _safe_reset(_TRACE_SOURCE, tokens.trace_source_token, "request")
+    _safe_reset(_REQUEST_METHOD, tokens.request_method_token, None)
+    _safe_reset(_REQUEST_PATH, tokens.request_path_token, None)
+    _SPAN_DEPTH.set(0)
+    _ACTIVE_PARENT_EXPORT.set(None)
+
+
+def current_trace_id() -> str | None:
+    return _TRACE_ID.get()
+
+
+def current_trace_source() -> str:
+    return _TRACE_SOURCE.get()
+
+
+def current_request_method() -> str | None:
+    return _REQUEST_METHOD.get()
+
+
+def current_request_path() -> str | None:
+    return _REQUEST_PATH.get()
+
+
+def setup_braintrust() -> None:
+    global _BRAINTRUST_ENABLED, _BRAINTRUST_INITIALIZED
+
+    if _BRAINTRUST_INITIALIZED:
+        return
+    _BRAINTRUST_INITIALIZED = True
+
+    if not settings.BRAINTRUST_TRACING_ENABLED:
+        logger.info("Braintrust tracing: disabled")
+        return
+
+    if _braintrust_init_logger is None:
+        logger.warning(
+            "Braintrust tracing enabled but `braintrust` package is unavailable."
+        )
+        return
+
+    project_id = settings.BRAINTRUST_PROJECT_ID.strip()
+    if not project_id:
+        logger.warning("Braintrust tracing enabled but no project ID is configured.")
+        return
+
+    init_kwargs: dict[str, Any] = {
+        "project_id": project_id,
+        "set_current": True,
+    }
+    if settings.BRAINTRUST_APP_URL:
+        init_kwargs["app_url"] = settings.BRAINTRUST_APP_URL
+    if settings.BRAINTRUST_API_KEY:
+        init_kwargs["api_key"] = settings.BRAINTRUST_API_KEY
+
+    try:
+        _braintrust_init_logger(**init_kwargs)
+    except Exception as exc:
+        logger.exception("Braintrust tracing initialization failed: %s", exc)
+        _BRAINTRUST_ENABLED = False
+        return
+
+    _BRAINTRUST_ENABLED = True
+    logger.info("Braintrust tracing: enabled (project_id=%s)", project_id)
+
+
+def flush_braintrust() -> None:
+    if not _BRAINTRUST_ENABLED or _braintrust_flush is None:
+        return
+
+    try:
+        _braintrust_flush()
+    except Exception as exc:
+        logger.exception("Braintrust tracing flush failed: %s", exc)
+
+
+@contextmanager
+def start_trace_span(
+    name: str,
+    *,
+    span_type: str | None = None,
+    input_data: Any | None = None,
+    output_data: Any | None = None,
+    metadata: dict[str, Any] | None = None,
+    metrics: dict[str, float | int] | None = None,
+    root_trace_id: str | None = None,
+):
+    if not _BRAINTRUST_ENABLED or _braintrust_start_span is None:
+        yield None
+        return
+
+    span_kwargs: dict[str, Any] = {"name": name}
+    if span_type:
+        span_kwargs["type"] = span_type
+
+    resolved_trace_id = root_trace_id or current_trace_id()
+    span_depth = _SPAN_DEPTH.get()
+    parent_export = _ACTIVE_PARENT_EXPORT.get()
+    if parent_export:
+        span_kwargs["parent"] = parent_export
+    elif resolved_trace_id and span_depth == 0:
+        span_kwargs["root_span_id"] = resolved_trace_id
+
+    event_kwargs: dict[str, Any] = {}
+    if input_data is not None:
+        event_kwargs["input"] = input_data
+    if output_data is not None:
+        event_kwargs["output"] = output_data
+    if metadata:
+        event_kwargs["metadata"] = metadata
+    if metrics:
+        event_kwargs["metrics"] = metrics
+
+    with _braintrust_start_span(**span_kwargs, **event_kwargs) as span:
+        span_depth_token = _SPAN_DEPTH.set(span_depth + 1)
+        parent_export_token: Token[str | None] | None = None
+        try:
+            export_fn = getattr(span, "export", None)
+            if callable(export_fn):
+                exported = export_fn()
+                if isinstance(exported, str) and exported:
+                    parent_export_token = _ACTIVE_PARENT_EXPORT.set(exported)
+        except Exception as exc:
+            logger.debug("Braintrust span export failed: %s", exc)
+
+        try:
+            yield span
+        finally:
+            if parent_export_token is not None:
+                _safe_reset(_ACTIVE_PARENT_EXPORT, parent_export_token, None)
+            _safe_reset(_SPAN_DEPTH, span_depth_token, max(0, span_depth))
+
+
+def log_span(span: Any, **event: Any) -> None:
+    if span is None:
+        return
+    if not event:
+        return
+
+    try:
+        span.log(**event)
+    except Exception as exc:
+        logger.debug("Braintrust span logging failed: %s", exc)

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,9 @@ from app.core.middleware import (
     RateLimitMiddleware,
     RequestSizeLimitMiddleware,
     RequestTimeoutMiddleware,
+    TraceContextMiddleware,
 )
+from app.core.tracing import flush_braintrust, setup_braintrust
 from app.routers import api
 from app.services.data.supabase_client import (
     close_connection_pool,
@@ -190,10 +192,14 @@ async def lifespan(app: FastAPI):
     else:
         logger.warning("API auth token: disabled")
 
+    setup_braintrust()
+
     # Initialize database connection pool
     init_connection_pool()
 
     yield
+
+    flush_braintrust()
 
     # Cleanup on shutdown
     close_connection_pool()
@@ -244,6 +250,10 @@ def create_application() -> FastAPI:
     application.add_middleware(
         RequestSizeLimitMiddleware,
         max_body_size_bytes=settings.MAX_REQUEST_SIZE_MB * 1024 * 1024,
+    )
+    application.add_middleware(
+        TraceContextMiddleware,
+        api_base_path=api_root_path,
     )
 
     return application

--- a/app/services/llm_generation_service.py
+++ b/app/services/llm_generation_service.py
@@ -595,7 +595,9 @@ def make_llm_call_structured_output_generic(
                             "success": False,
                             "attempt": attempt,
                             **_assistant_output_payload(
-                                json.dumps(response_data, default=str, ensure_ascii=True)
+                                json.dumps(
+                                    response_data, default=str, ensure_ascii=True
+                                )
                             ),
                             "response": response_data,
                         },

--- a/app/services/llm_generation_service.py
+++ b/app/services/llm_generation_service.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 from collections.abc import Iterator
-from typing import Callable, Optional, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from app.core.cache import hash_cache_key, llm_structured_cache, llm_text_cache
 from openai import OpenAI
@@ -14,6 +14,7 @@ from openai.types.shared_params import ResponseFormatJSONSchema
 from pydantic import BaseModel
 
 from app.core.config import settings
+from app.core.tracing import log_span, start_trace_span
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -77,32 +78,119 @@ def _with_retries(fn: Callable[[], T]) -> T:
     raise RuntimeError("LLM call failed without exception")
 
 
+def _usage_to_metrics(usage: object | None) -> dict[str, int]:
+    if usage is None:
+        return {}
+
+    metrics: dict[str, int] = {}
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    total_tokens = getattr(usage, "total_tokens", None)
+
+    if isinstance(prompt_tokens, int):
+        metrics["prompt_tokens"] = prompt_tokens
+    if isinstance(completion_tokens, int):
+        metrics["completion_tokens"] = completion_tokens
+    if isinstance(total_tokens, int):
+        metrics["tokens"] = total_tokens
+    return metrics
+
+
+def _text_prompt_summary(
+    user_prompt: str,
+    system_prompt: str,
+) -> dict[str, int]:
+    return {
+        "user_prompt_chars": len(user_prompt),
+        "system_prompt_chars": len(system_prompt),
+    }
+
+
+def _text_prompt_payload(
+    user_prompt: str,
+    system_prompt: str,
+) -> dict[str, list[dict[str, str]]]:
+    return {
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+    }
+
+
+def _assistant_output_payload(content: str | None) -> dict[str, list[dict[str, str]]]:
+    return {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": content or "",
+            }
+        ]
+    }
+
+
 def make_llm_call_text_generation(user_prompt: str, system_prompt: str) -> str:
     model_name = _get_chat_model_name()
     if not model_name:
         raise ValueError("LLM model name is not set.")
 
     cache_key = hash_cache_key("llm_text", model_name, system_prompt, user_prompt)
-    cached = llm_text_cache.get(cache_key)
-    if cached is not None:
-        return cached
+    prompt_summary = _text_prompt_summary(user_prompt, system_prompt)
+    prompt_payload = _text_prompt_payload(user_prompt, system_prompt)
 
-    messages: list[
-        Union[ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam]
-    ] = [
-        ChatCompletionSystemMessageParam(role="system", content=system_prompt),
-        ChatCompletionUserMessageParam(role="user", content=user_prompt),
-    ]
+    with start_trace_span(
+        name="llm.text_generation",
+        span_type="llm",
+        input_data=prompt_payload,
+        metadata={
+            "model": model_name,
+            "cache_key": cache_key,
+            "stream": False,
+            **prompt_summary,
+        },
+    ) as span:
+        cached = llm_text_cache.get(cache_key)
+        if cached is not None:
+            log_span(
+                span,
+                output={
+                    **_assistant_output_payload(cached),
+                    "content": cached,
+                    "content_chars": len(cached),
+                },
+                metadata={"cache_hit": True},
+            )
+            return cached
 
-    client = _get_openai_client()
-    completion = _with_retries(
-        lambda: client.chat.completions.create(model=model_name, messages=messages)
-    )
-    content = completion.choices[0].message.content
-    logger.info("Text generation response received")
-    if content is not None:
-        llm_text_cache.set(cache_key, content)
-    return content
+        messages: list[
+            Union[ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam]
+        ] = [
+            ChatCompletionSystemMessageParam(role="system", content=system_prompt),
+            ChatCompletionUserMessageParam(role="user", content=user_prompt),
+        ]
+
+        client = _get_openai_client()
+        completion = _with_retries(
+            lambda: client.chat.completions.create(model=model_name, messages=messages)
+        )
+        content = completion.choices[0].message.content
+        logger.info("Text generation response received")
+
+        usage_metrics = _usage_to_metrics(getattr(completion, "usage", None))
+        log_span(
+            span,
+            output={
+                **_assistant_output_payload(content),
+                "content": content,
+                "content_chars": len(content or ""),
+            },
+            metadata={"cache_hit": False},
+            metrics=usage_metrics,
+        )
+
+        if content is not None:
+            llm_text_cache.set(cache_key, content)
+        return content
 
 
 def stream_llm_call_text_generation(
@@ -114,41 +202,99 @@ def stream_llm_call_text_generation(
         raise ValueError("LLM model name is not set.")
 
     cache_key = hash_cache_key("llm_text", model_name, system_prompt, user_prompt)
-    cached = llm_text_cache.get(cache_key)
-    if cached is not None:
-        yield cached
-        return
+    prompt_summary = _text_prompt_summary(user_prompt, system_prompt)
+    prompt_payload = _text_prompt_payload(user_prompt, system_prompt)
 
-    messages: list[
-        Union[ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam]
-    ] = [
-        ChatCompletionSystemMessageParam(role="system", content=system_prompt),
-        ChatCompletionUserMessageParam(role="user", content=user_prompt),
-    ]
+    with start_trace_span(
+        name="llm.text_generation.stream",
+        span_type="llm",
+        input_data=prompt_payload,
+        metadata={
+            "model": model_name,
+            "cache_key": cache_key,
+            "stream": True,
+            **prompt_summary,
+        },
+    ) as span:
+        cached = llm_text_cache.get(cache_key)
+        if cached is not None:
+            log_span(
+                span,
+                output={
+                    **_assistant_output_payload(cached),
+                    "content": cached,
+                    "content_chars": len(cached),
+                },
+                metadata={"cache_hit": True},
+            )
+            yield cached
+            return
 
-    client = _get_openai_client()
-    stream = _with_retries(
-        lambda: client.chat.completions.create(
-            model=model_name,
-            messages=messages,
-            stream=True,
+        messages: list[
+            Union[ChatCompletionSystemMessageParam, ChatCompletionUserMessageParam]
+        ] = [
+            ChatCompletionSystemMessageParam(role="system", content=system_prompt),
+            ChatCompletionUserMessageParam(role="user", content=user_prompt),
+        ]
+
+        client = _get_openai_client()
+        stream = _with_retries(
+            lambda: client.chat.completions.create(
+                model=model_name,
+                messages=messages,
+                stream=True,
+            )
         )
-    )
 
-    parts: list[str] = []
-    for chunk in stream:
-        if not chunk.choices:
-            continue
-        delta = chunk.choices[0].delta
-        text = getattr(delta, "content", None)
-        if not text:
-            continue
-        parts.append(text)
-        yield text
+        parts: list[str] = []
+        chunk_count = 0
+        stream_completed = False
+        stream_interrupted = False
+        stream_error: str | None = None
 
-    content = "".join(parts)
-    if content:
-        llm_text_cache.set(cache_key, content)
+        try:
+            for chunk in stream:
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                text = getattr(delta, "content", None)
+                if not text:
+                    continue
+                chunk_count += 1
+                parts.append(text)
+                yield text
+            stream_completed = True
+        except GeneratorExit:
+            stream_interrupted = True
+            stream_error = "stream closed before completion"
+            raise
+        except Exception as exc:
+            stream_error = str(exc)
+            raise
+        finally:
+            content = "".join(parts)
+            if stream_completed and content:
+                llm_text_cache.set(cache_key, content)
+
+            span_metadata: dict[str, Any] = {
+                "cache_hit": False,
+                "stream_completed": stream_completed,
+            }
+            if stream_interrupted:
+                span_metadata["stream_interrupted"] = True
+            if stream_error:
+                span_metadata["stream_error"] = stream_error
+
+            log_span(
+                span,
+                output={
+                    **_assistant_output_payload(content),
+                    "content": content,
+                    "content_chars": len(content),
+                    "chunk_count": chunk_count,
+                },
+                metadata=span_metadata,
+            )
 
 
 def make_llm_call_structured_output_generic(
@@ -171,179 +317,310 @@ def make_llm_call_structured_output_generic(
         result contains the model instance and error_message is None.
         If failed, result is None and error_message contains the error.
     """
-    try:
-        model_name = _get_chat_model_name()
-        if not model_name:
-            raise ValueError("LLM model name is not set.")
+    span_metadata: dict[str, Any] = {
+        "schema_name": schema_name,
+        "model_class": f"{model_class.__module__}.{model_class.__name__}",
+    }
+    span_input = {
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "schema_name": schema_name,
+    }
+    prompt_summary = _text_prompt_summary(user_prompt, system_prompt)
 
-        schema = model_class.model_json_schema()
-        schema_fingerprint = json.dumps(schema, sort_keys=True)
-        cache_key = hash_cache_key(
-            "llm_structured",
-            model_name,
-            system_prompt,
-            user_prompt,
-            schema_name,
-            model_class.__module__,
-            model_class.__name__,
-            schema_fingerprint,
-        )
-        cached = llm_structured_cache.get(cache_key)
-        if cached is not None:
-            try:
-                return model_class.model_validate(cached), None
-            except Exception as exc:
-                logger.warning(
-                    "Cached structured response failed validation; evicting. Error: %s",
-                    exc,
-                )
-                llm_structured_cache.delete(cache_key)
+    with start_trace_span(
+        name="llm.structured_output",
+        span_type="llm",
+        input_data=span_input,
+        metadata={**span_metadata, **prompt_summary},
+    ) as span:
+        try:
+            model_name = _get_chat_model_name()
+            if not model_name:
+                raise ValueError("LLM model name is not set.")
+            span_metadata["model"] = model_name
 
-        client = _get_openai_client()
-
-        response_format = ResponseFormatJSONSchema(
-            type="json_schema",
-            json_schema={"name": schema_name, "schema": schema},
-        )
-        max_attempts = settings.LLM_STRUCTURED_OUTPUT_MAX_ATTEMPTS
-        base_max_tokens = max(1, settings.LLM_STRUCTURED_MAX_TOKENS)
-        last_error_msg: Optional[str] = None
-
-        for attempt in range(1, max_attempts + 1):
-            attempt_max_tokens = base_max_tokens * attempt
-
-            completion = _with_retries(
-                lambda: client.chat.completions.create(
-                    model=model_name,
-                    messages=[
-                        ChatCompletionSystemMessageParam(
-                            role="system", content=system_prompt
-                        ),
-                        ChatCompletionUserMessageParam(
-                            role="user", content=user_prompt
-                        ),
-                    ],
-                    response_format=response_format,
-                    max_tokens=attempt_max_tokens,
-                )
+            schema = model_class.model_json_schema()
+            schema_fingerprint = json.dumps(schema, sort_keys=True)
+            cache_key = hash_cache_key(
+                "llm_structured",
+                model_name,
+                system_prompt,
+                user_prompt,
+                schema_name,
+                model_class.__module__,
+                model_class.__name__,
+                schema_fingerprint,
             )
+            span_metadata["cache_key"] = cache_key
 
-            if not completion.choices:
-                error_msg = "LLM API returned no choices for structured output."
-                logger.error(error_msg)
-                last_error_msg = error_msg
-                if attempt < max_attempts:
+            cached = llm_structured_cache.get(cache_key)
+            if cached is not None:
+                try:
+                    result = model_class.model_validate(cached)
+                    cached_payload = result.model_dump()
+                    cached_content = json.dumps(
+                        cached_payload,
+                        ensure_ascii=True,
+                        sort_keys=True,
+                    )
+                    log_span(
+                        span,
+                        output={
+                            "success": True,
+                            "cache_hit": True,
+                            **_assistant_output_payload(cached_content),
+                            "content": cached_content,
+                            "response": cached_payload,
+                        },
+                        metadata={"cache_hit": True},
+                    )
+                    return result, None
+                except Exception as exc:
                     logger.warning(
-                        "Retrying structured output after empty choices "
-                        "(attempt %s/%s).",
-                        attempt + 1,
-                        max_attempts,
+                        "Cached structured response failed validation; evicting. Error: %s",
+                        exc,
                     )
-                    continue
-                return None, error_msg
+                    llm_structured_cache.delete(cache_key)
 
-            choice = completion.choices[0]
-            message = choice.message
-            content = message.content
-            logger.info(
-                "Structured output response (attempt %s/%s): %r",
-                attempt,
-                max_attempts,
-                content,
+            client = _get_openai_client()
+
+            response_format = ResponseFormatJSONSchema(
+                type="json_schema",
+                json_schema={"name": schema_name, "schema": schema},
             )
+            max_attempts = settings.LLM_STRUCTURED_OUTPUT_MAX_ATTEMPTS
+            base_max_tokens = max(1, settings.LLM_STRUCTURED_MAX_TOKENS)
+            last_error_msg: Optional[str] = None
 
-            if content is None:
-                refusal = getattr(message, "refusal", None)
-                finish_reason = getattr(choice, "finish_reason", None)
-                has_tool_calls = bool(getattr(message, "tool_calls", None))
-                error_parts = ["Model returned no JSON content."]
-                if refusal:
-                    error_parts.append(f"Refusal: {refusal}")
-                if finish_reason:
-                    error_parts.append(f"finish_reason={finish_reason}")
-                if has_tool_calls:
-                    error_parts.append(
-                        "Response contained tool calls instead of content."
+            for attempt in range(1, max_attempts + 1):
+                attempt_max_tokens = base_max_tokens * attempt
+
+                completion = _with_retries(
+                    lambda: client.chat.completions.create(
+                        model=model_name,
+                        messages=[
+                            ChatCompletionSystemMessageParam(
+                                role="system", content=system_prompt
+                            ),
+                            ChatCompletionUserMessageParam(
+                                role="user", content=user_prompt
+                            ),
+                        ],
+                        response_format=response_format,
+                        max_tokens=attempt_max_tokens,
                     )
-                error_msg = " ".join(error_parts)
-                logger.error(error_msg)
-                last_error_msg = error_msg
-                if refusal:
+                )
+
+                usage_metrics = _usage_to_metrics(getattr(completion, "usage", None))
+
+                if not completion.choices:
+                    error_msg = "LLM API returned no choices for structured output."
+                    logger.error(error_msg)
+                    last_error_msg = error_msg
+                    if attempt < max_attempts:
+                        logger.warning(
+                            "Retrying structured output after empty choices "
+                            "(attempt %s/%s).",
+                            attempt + 1,
+                            max_attempts,
+                        )
+                        continue
+                    log_span(
+                        span,
+                        output={
+                            "success": False,
+                            "attempt": attempt,
+                            **_assistant_output_payload(None),
+                            "response": None,
+                        },
+                        metadata={"cache_hit": False, "error": error_msg},
+                        metrics=usage_metrics,
+                    )
                     return None, error_msg
-                if attempt < max_attempts:
-                    logger.warning(
-                        "Retrying structured output after missing content "
-                        "(attempt %s/%s). finish_reason=%s",
-                        attempt + 1,
-                        max_attempts,
-                        finish_reason,
-                    )
-                    continue
-                return None, error_msg
 
-            if not isinstance(content, (str, bytes, bytearray)):
-                error_msg = (
-                    "Model returned unsupported content type for JSON parsing: "
-                    f"{type(content).__name__}"
+                choice = completion.choices[0]
+                message = choice.message
+                content = message.content
+                logger.info(
+                    "Structured output response (attempt %s/%s): %r",
+                    attempt,
+                    max_attempts,
+                    content,
                 )
-                logger.error(error_msg)
-                last_error_msg = error_msg
-                if attempt < max_attempts:
-                    logger.warning(
-                        "Retrying structured output after unsupported content type "
-                        "(attempt %s/%s).",
-                        attempt + 1,
-                        max_attempts,
-                    )
-                    continue
-                return None, error_msg
 
-            content_text = (
-                content
-                if isinstance(content, str)
-                else content.decode("utf-8", errors="replace")
+                if content is None:
+                    refusal = getattr(message, "refusal", None)
+                    finish_reason = getattr(choice, "finish_reason", None)
+                    has_tool_calls = bool(getattr(message, "tool_calls", None))
+                    error_parts = ["Model returned no JSON content."]
+                    if refusal:
+                        error_parts.append(f"Refusal: {refusal}")
+                    if finish_reason:
+                        error_parts.append(f"finish_reason={finish_reason}")
+                    if has_tool_calls:
+                        error_parts.append(
+                            "Response contained tool calls instead of content."
+                        )
+                    error_msg = " ".join(error_parts)
+                    logger.error(error_msg)
+                    last_error_msg = error_msg
+                    if refusal:
+                        log_span(
+                            span,
+                            output={
+                                "success": False,
+                                "attempt": attempt,
+                                **_assistant_output_payload(None),
+                                "response": None,
+                            },
+                            metadata={"cache_hit": False, "error": error_msg},
+                            metrics=usage_metrics,
+                        )
+                        return None, error_msg
+                    if attempt < max_attempts:
+                        logger.warning(
+                            "Retrying structured output after missing content "
+                            "(attempt %s/%s). finish_reason=%s",
+                            attempt + 1,
+                            max_attempts,
+                            finish_reason,
+                        )
+                        continue
+                    log_span(
+                        span,
+                        output={
+                            "success": False,
+                            "attempt": attempt,
+                            **_assistant_output_payload(None),
+                            "response": None,
+                        },
+                        metadata={"cache_hit": False, "error": error_msg},
+                        metrics=usage_metrics,
+                    )
+                    return None, error_msg
+
+                if not isinstance(content, (str, bytes, bytearray)):
+                    error_msg = (
+                        "Model returned unsupported content type for JSON parsing: "
+                        f"{type(content).__name__}"
+                    )
+                    logger.error(error_msg)
+                    last_error_msg = error_msg
+                    if attempt < max_attempts:
+                        logger.warning(
+                            "Retrying structured output after unsupported content type "
+                            "(attempt %s/%s).",
+                            attempt + 1,
+                            max_attempts,
+                        )
+                        continue
+                    log_span(
+                        span,
+                        output={
+                            "success": False,
+                            "attempt": attempt,
+                            **_assistant_output_payload(str(content)),
+                            "response": str(content),
+                        },
+                        metadata={"cache_hit": False, "error": error_msg},
+                        metrics=usage_metrics,
+                    )
+                    return None, error_msg
+
+                content_text = (
+                    content
+                    if isinstance(content, str)
+                    else content.decode("utf-8", errors="replace")
+                )
+
+                try:
+                    response_data = json.loads(content_text)
+                    result = model_class.model_validate(response_data)
+                    llm_structured_cache.set(cache_key, result.model_dump())
+                    log_span(
+                        span,
+                        output={
+                            "success": True,
+                            "attempt": attempt,
+                            **_assistant_output_payload(content_text),
+                            "content": content_text,
+                            "response": response_data,
+                        },
+                        metadata={"cache_hit": False},
+                        metrics=usage_metrics,
+                    )
+                    return result, None
+                except json.JSONDecodeError as e:
+                    error_msg = f"Failed to parse JSON response: {e}. Raw content: {content_text!r}"
+                    logger.error(error_msg)
+                    last_error_msg = error_msg
+                    if attempt < max_attempts:
+                        logger.warning(
+                            "Retrying structured output after JSON parse failure "
+                            "(attempt %s/%s).",
+                            attempt + 1,
+                            max_attempts,
+                        )
+                        continue
+                    log_span(
+                        span,
+                        output={
+                            "success": False,
+                            "attempt": attempt,
+                            **_assistant_output_payload(content_text),
+                            "response": content_text,
+                        },
+                        metadata={"cache_hit": False, "error": error_msg},
+                        metrics=usage_metrics,
+                    )
+                    return None, error_msg
+                except Exception as e:
+                    error_msg = f"Failed to validate response data: {e}"
+                    logger.error(error_msg)
+                    last_error_msg = error_msg
+                    if attempt < max_attempts:
+                        logger.warning(
+                            "Retrying structured output after validation failure "
+                            "(attempt %s/%s).",
+                            attempt + 1,
+                            max_attempts,
+                        )
+                        continue
+                    log_span(
+                        span,
+                        output={
+                            "success": False,
+                            "attempt": attempt,
+                            **_assistant_output_payload(
+                                json.dumps(response_data, default=str, ensure_ascii=True)
+                            ),
+                            "response": response_data,
+                        },
+                        metadata={"cache_hit": False, "error": error_msg},
+                        metrics=usage_metrics,
+                    )
+                    return None, error_msg
+
+            final_error = last_error_msg or "Structured output failed without an error"
+            log_span(
+                span,
+                output={
+                    "success": False,
+                    **_assistant_output_payload(None),
+                    "response": None,
+                },
+                metadata={"cache_hit": False, "error": final_error},
             )
+            return None, final_error
 
-            try:
-                response_data = json.loads(content_text)
-                result = model_class.model_validate(response_data)
-                llm_structured_cache.set(cache_key, result.model_dump())
-                return result, None
-            except json.JSONDecodeError as e:
-                error_msg = (
-                    f"Failed to parse JSON response: {e}. Raw content: {content_text!r}"
-                )
-                logger.error(error_msg)
-                last_error_msg = error_msg
-                if attempt < max_attempts:
-                    logger.warning(
-                        "Retrying structured output after JSON parse failure "
-                        "(attempt %s/%s).",
-                        attempt + 1,
-                        max_attempts,
-                    )
-                    continue
-                return None, error_msg
-            except Exception as e:
-                error_msg = f"Failed to validate response data: {e}"
-                logger.error(error_msg)
-                last_error_msg = error_msg
-                if attempt < max_attempts:
-                    logger.warning(
-                        "Retrying structured output after validation failure "
-                        "(attempt %s/%s).",
-                        attempt + 1,
-                        max_attempts,
-                    )
-                    continue
-                return None, error_msg
-
-        return None, last_error_msg or "Structured output failed without an error"
-
-    except Exception as e:
-        error_msg = f"LLM API call failed: {e}"
-        logger.error(error_msg)
-        return None, error_msg
+        except Exception as e:
+            error_msg = f"LLM API call failed: {e}"
+            logger.error(error_msg)
+            log_span(span, error=error_msg)
+            return None, error_msg
 
 
 def make_embedding(text: str) -> list[float]:
@@ -351,8 +628,21 @@ def make_embedding(text: str) -> list[float]:
     if not model_name:
         raise ValueError("Embeddings model name is not set.")
 
-    client = _get_openai_client()
-    response = _with_retries(
-        lambda: client.embeddings.create(model=model_name, input=text)
-    )
-    return response.data[0].embedding
+    with start_trace_span(
+        name="llm.embedding",
+        span_type="llm",
+        input_data={"text": text},
+        metadata={"model": model_name, "input_chars": len(text)},
+    ) as span:
+        client = _get_openai_client()
+        response = _with_retries(
+            lambda: client.embeddings.create(model=model_name, input=text)
+        )
+        embedding = response.data[0].embedding
+        usage_metrics = _usage_to_metrics(getattr(response, "usage", None))
+        log_span(
+            span,
+            output={"embedding": embedding, "embedding_dimensions": len(embedding)},
+            metrics=usage_metrics,
+        )
+        return embedding

--- a/app/tests/unit/test_llm_generation_service_cache.py
+++ b/app/tests/unit/test_llm_generation_service_cache.py
@@ -52,10 +52,14 @@ def test_stream_llm_call_text_generation_logs_output_on_completion(
             return iter(
                 [
                     SimpleNamespace(
-                        choices=[SimpleNamespace(delta=SimpleNamespace(content="hello "))]
+                        choices=[
+                            SimpleNamespace(delta=SimpleNamespace(content="hello "))
+                        ]
                     ),
                     SimpleNamespace(
-                        choices=[SimpleNamespace(delta=SimpleNamespace(content="world"))]
+                        choices=[
+                            SimpleNamespace(delta=SimpleNamespace(content="world"))
+                        ]
                     ),
                 ]
             )
@@ -106,10 +110,14 @@ def test_stream_llm_call_text_generation_logs_output_when_closed_early(
             return iter(
                 [
                     SimpleNamespace(
-                        choices=[SimpleNamespace(delta=SimpleNamespace(content="hello "))]
+                        choices=[
+                            SimpleNamespace(delta=SimpleNamespace(content="hello "))
+                        ]
                     ),
                     SimpleNamespace(
-                        choices=[SimpleNamespace(delta=SimpleNamespace(content="world"))]
+                        choices=[
+                            SimpleNamespace(delta=SimpleNamespace(content="world"))
+                        ]
                     ),
                 ]
             )

--- a/app/tests/unit/test_llm_generation_service_cache.py
+++ b/app/tests/unit/test_llm_generation_service_cache.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -41,3 +42,111 @@ def test_make_llm_call_text_generation_caches_empty_string(monkeypatch) -> None:
     assert first == ""
     assert second == ""
     assert fake_completions.calls == 1
+
+
+def test_stream_llm_call_text_generation_logs_output_on_completion(
+    monkeypatch,
+) -> None:
+    class _FakeCompletionsStream:
+        def create(self, **_kwargs):
+            return iter(
+                [
+                    SimpleNamespace(
+                        choices=[SimpleNamespace(delta=SimpleNamespace(content="hello "))]
+                    ),
+                    SimpleNamespace(
+                        choices=[SimpleNamespace(delta=SimpleNamespace(content="world"))]
+                    ),
+                ]
+            )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=_FakeCompletionsStream())
+    )
+    cache = TTLCache[str](ttl_seconds=60, max_items=10)
+    captured_logs: list[dict] = []
+
+    @contextmanager
+    def _fake_span(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_text_cache", cache)
+    monkeypatch.setattr(llm_generation_service, "start_trace_span", _fake_span)
+    monkeypatch.setattr(
+        llm_generation_service,
+        "log_span",
+        lambda _span, **event: captured_logs.append(event),
+    )
+
+    chunks = list(
+        llm_generation_service.stream_llm_call_text_generation(
+            user_prompt="u", system_prompt="s"
+        )
+    )
+
+    assert chunks == ["hello ", "world"]
+    assert captured_logs
+    final_log = captured_logs[-1]
+    assert final_log["output"]["content"] == "hello world"
+    assert final_log["output"]["messages"][0]["role"] == "assistant"
+    assert final_log["output"]["messages"][0]["content"] == "hello world"
+    assert final_log["metadata"]["stream_completed"] is True
+    assert "stream_interrupted" not in final_log["metadata"]
+
+
+def test_stream_llm_call_text_generation_logs_output_when_closed_early(
+    monkeypatch,
+) -> None:
+    class _FakeCompletionsStream:
+        def create(self, **_kwargs):
+            return iter(
+                [
+                    SimpleNamespace(
+                        choices=[SimpleNamespace(delta=SimpleNamespace(content="hello "))]
+                    ),
+                    SimpleNamespace(
+                        choices=[SimpleNamespace(delta=SimpleNamespace(content="world"))]
+                    ),
+                ]
+            )
+
+    fake_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=_FakeCompletionsStream())
+    )
+    cache = TTLCache[str](ttl_seconds=60, max_items=10)
+    captured_logs: list[dict] = []
+
+    @contextmanager
+    def _fake_span(*_args, **_kwargs):
+        yield object()
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_text_cache", cache)
+    monkeypatch.setattr(llm_generation_service, "start_trace_span", _fake_span)
+    monkeypatch.setattr(
+        llm_generation_service,
+        "log_span",
+        lambda _span, **event: captured_logs.append(event),
+    )
+
+    stream = llm_generation_service.stream_llm_call_text_generation(
+        user_prompt="u",
+        system_prompt="s",
+    )
+    assert next(stream) == "hello "
+    stream.close()
+
+    assert captured_logs
+    final_log = captured_logs[-1]
+    assert final_log["output"]["content"] == "hello "
+    assert final_log["output"]["messages"][0]["role"] == "assistant"
+    assert final_log["output"]["messages"][0]["content"] == "hello "
+    assert final_log["metadata"]["stream_completed"] is False
+    assert final_log["metadata"]["stream_interrupted"] is True

--- a/app/tests/unit/test_llm_generation_service_structured_output.py
+++ b/app/tests/unit/test_llm_generation_service_structured_output.py
@@ -201,7 +201,9 @@ def test_structured_output_logs_assistant_message_payload(monkeypatch) -> None:
     monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
     monkeypatch.setattr(llm_generation_service, "start_trace_span", _fake_span)
     monkeypatch.setattr(
-        llm_generation_service, "log_span", lambda _span, **event: log_events.append(event)
+        llm_generation_service,
+        "log_span",
+        lambda _span, **event: log_events.append(event),
     )
 
     suffix = uuid4().hex

--- a/app/tests/unit/test_llm_generation_service_structured_output.py
+++ b/app/tests/unit/test_llm_generation_service_structured_output.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -176,3 +177,47 @@ def test_structured_output_returns_error_after_retry_exhaustion(monkeypatch) -> 
     assert error is not None
     assert "Failed to parse JSON response" in error
     assert fake_completions.calls == 2
+
+
+def test_structured_output_logs_assistant_message_payload(monkeypatch) -> None:
+    fake_completions = _SequenceStructuredCompletions(
+        responses=[{"content": '{"ingredients":["1 tomato"]}', "finish_reason": "stop"}]
+    )
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=fake_completions))
+    cache = TTLCache[dict](ttl_seconds=60, max_items=10)
+
+    span_calls: list[dict] = []
+    log_events: list[dict] = []
+
+    @contextmanager
+    def _fake_span(**kwargs):
+        span_calls.append(kwargs)
+        yield object()
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
+    monkeypatch.setattr(llm_generation_service, "start_trace_span", _fake_span)
+    monkeypatch.setattr(
+        llm_generation_service, "log_span", lambda _span, **event: log_events.append(event)
+    )
+
+    suffix = uuid4().hex
+    result, error = llm_generation_service.make_llm_call_structured_output_generic(
+        user_prompt=f"user-prompt-{suffix}",
+        system_prompt=f"system-prompt-{suffix}",
+        model_class=_StructuredResponseModel,
+        schema_name="structured_output_trace_message_format_test",
+    )
+
+    assert error is None
+    assert result is not None
+    assert span_calls
+    assert span_calls[0]["input_data"]["messages"][0]["role"] == "system"
+    assert span_calls[0]["input_data"]["messages"][1]["role"] == "user"
+    assert log_events
+    final_output = log_events[-1]["output"]
+    assert final_output["messages"][0]["role"] == "assistant"
+    assert final_output["messages"][0]["content"] == '{"ingredients":["1 tomato"]}'

--- a/app/tests/unit/test_trace_context_middleware.py
+++ b/app/tests/unit/test_trace_context_middleware.py
@@ -1,0 +1,84 @@
+import json
+from uuid import UUID, uuid4
+
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+from app.core.middleware import TraceContextMiddleware
+from app.core.tracing import current_trace_id, current_trace_source
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/v1/recipes/probe")
+    async def recipe_probe() -> dict[str, str | None]:
+        return {
+            "trace_id": current_trace_id(),
+            "trace_source": current_trace_source(),
+        }
+
+    @app.get("/api/v1/experiments/threads/{thread_id}/probe")
+    async def thread_probe(thread_id: str) -> dict[str, str | None]:
+        return {
+            "thread_id": thread_id,
+            "trace_id": current_trace_id(),
+            "trace_source": current_trace_source(),
+        }
+
+    @app.get("/api/v1/experiments/threads/{thread_id}/stream")
+    async def thread_stream(thread_id: str):
+        def event_stream():
+            payload = {
+                "thread_id": thread_id,
+                "trace_id": current_trace_id(),
+                "trace_source": current_trace_source(),
+            }
+            yield f"data: {json.dumps(payload)}\n\n"
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    app.add_middleware(TraceContextMiddleware, api_base_path="/api/v1")
+    return app
+
+
+def test_trace_context_uses_request_id_outside_experiment_threads() -> None:
+    client = TestClient(_build_app())
+
+    response = client.get("/api/v1/recipes/probe")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["trace_source"] == "request"
+    assert body["trace_id"]
+    assert str(UUID(body["trace_id"])) == body["trace_id"]
+
+
+def test_trace_context_uses_thread_id_for_experiment_thread_routes() -> None:
+    client = TestClient(_build_app())
+    thread_id = str(uuid4())
+
+    response = client.get(f"/api/v1/experiments/threads/{thread_id}/probe")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["thread_id"] == thread_id
+    assert body["trace_source"] == "thread"
+    assert body["trace_id"] == thread_id
+
+
+def test_trace_context_is_available_during_streaming_response() -> None:
+    client = TestClient(_build_app())
+    thread_id = str(uuid4())
+
+    response = client.get(f"/api/v1/experiments/threads/{thread_id}/stream")
+
+    assert response.status_code == 200
+    data_line = next(
+        line for line in response.text.splitlines() if line.startswith("data: ")
+    )
+    payload = json.loads(data_line[len("data: ") :])
+    assert payload["thread_id"] == thread_id
+    assert payload["trace_source"] == "thread"
+    assert payload["trace_id"] == thread_id

--- a/app/tests/unit/test_tracing.py
+++ b/app/tests/unit/test_tracing.py
@@ -1,0 +1,40 @@
+from contextlib import contextmanager
+
+from app.core import tracing
+
+
+def test_nested_trace_spans_do_not_reapply_root_span_id(monkeypatch) -> None:
+    span_calls: list[dict] = []
+
+    class _FakeSpan:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def export(self) -> str:
+            return f"export:{self._name}"
+
+    @contextmanager
+    def _fake_start_span(**kwargs):
+        span_calls.append(kwargs)
+        yield _FakeSpan(str(kwargs.get("name", "")))
+
+    monkeypatch.setattr(tracing, "_BRAINTRUST_ENABLED", True)
+    monkeypatch.setattr(tracing, "_braintrust_start_span", _fake_start_span)
+
+    tokens = tracing.bind_trace_context(
+        trace_id="trace-123",
+        source="request",
+        request_method="GET",
+        request_path="/api/v1/test",
+    )
+    try:
+        with tracing.start_trace_span(name="root-span", span_type="task"):
+            with tracing.start_trace_span(name="child-span", span_type="llm"):
+                pass
+    finally:
+        tracing.reset_trace_context(tokens)
+
+    assert len(span_calls) == 2
+    assert span_calls[0]["root_span_id"] == "trace-123"
+    assert "root_span_id" not in span_calls[1]
+    assert span_calls[1]["parent"] == "export:root-span"

--- a/app/tests/unit/test_tracing.py
+++ b/app/tests/unit/test_tracing.py
@@ -3,7 +3,9 @@ from contextlib import contextmanager
 from app.core import tracing
 
 
-def test_nested_trace_spans_do_not_reapply_root_span_id(monkeypatch) -> None:
+def test_nested_trace_spans_use_parent_export_without_synthetic_root(
+    monkeypatch,
+) -> None:
     span_calls: list[dict] = []
 
     class _FakeSpan:
@@ -35,6 +37,76 @@ def test_nested_trace_spans_do_not_reapply_root_span_id(monkeypatch) -> None:
         tracing.reset_trace_context(tokens)
 
     assert len(span_calls) == 2
-    assert span_calls[0]["root_span_id"] == "trace-123"
+    assert "root_span_id" not in span_calls[0]
     assert "root_span_id" not in span_calls[1]
     assert span_calls[1]["parent"] == "export:root-span"
+    assert span_calls[0]["metadata"]["request_trace_id"] == "trace-123"
+    assert span_calls[0]["metadata"]["request_method"] == "GET"
+    assert span_calls[0]["metadata"]["request_path"] == "/api/v1/test"
+    assert span_calls[0]["metadata"]["trace_source"] == "request"
+
+
+def test_top_level_span_can_set_explicit_root_trace_id(monkeypatch) -> None:
+    span_calls: list[dict] = []
+
+    class _FakeSpan:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def export(self) -> str:
+            return f"export:{self._name}"
+
+    @contextmanager
+    def _fake_start_span(**kwargs):
+        span_calls.append(kwargs)
+        yield _FakeSpan(str(kwargs.get("name", "")))
+
+    monkeypatch.setattr(tracing, "_BRAINTRUST_ENABLED", True)
+    monkeypatch.setattr(tracing, "_braintrust_start_span", _fake_start_span)
+
+    tokens = tracing.bind_trace_context(
+        trace_id="trace-123",
+        source="request",
+        request_method="POST",
+        request_path="/api/v1/recipes",
+    )
+    try:
+        with tracing.start_trace_span(
+            name="top-level",
+            span_type="llm",
+            root_trace_id="explicit-root",
+        ):
+            with tracing.start_trace_span(name="child", span_type="task"):
+                pass
+    finally:
+        tracing.reset_trace_context(tokens)
+
+    assert len(span_calls) == 2
+    assert span_calls[0]["root_span_id"] == "explicit-root"
+    assert "root_span_id" not in span_calls[1]
+    assert span_calls[1]["parent"] == "export:top-level"
+
+
+def test_setup_braintrust_requires_api_key(monkeypatch) -> None:
+    init_calls: list[dict] = []
+
+    def _fake_init_logger(**kwargs) -> None:
+        init_calls.append(kwargs)
+
+    monkeypatch.setattr(tracing, "_braintrust_init_logger", _fake_init_logger)
+    monkeypatch.setattr(tracing, "_BRAINTRUST_ENABLED", False)
+    monkeypatch.setattr(tracing, "_BRAINTRUST_INITIALIZED", False)
+    monkeypatch.setattr(tracing.settings, "BRAINTRUST_TRACING_ENABLED", True)
+    monkeypatch.setattr(tracing.settings, "BRAINTRUST_PROJECT_ID", "project-123")
+    monkeypatch.setattr(
+        tracing.settings,
+        "BRAINTRUST_APP_URL",
+        "https://www.braintrust.dev",
+    )
+    monkeypatch.setattr(tracing.settings, "BRAINTRUST_API_KEY", "")
+
+    tracing.setup_braintrust()
+
+    assert tracing._BRAINTRUST_INITIALIZED is True
+    assert tracing._BRAINTRUST_ENABLED is False
+    assert not init_calls

--- a/config/app.config.ini
+++ b/config/app.config.ini
@@ -46,3 +46,8 @@ distance_threshold = 0.30
 
 [search]
 keywords_file = config/search_keywords.json
+
+[observability]
+braintrust_enabled = true
+braintrust_project_id = 4e61341a-cc9a-4ce4-a107-4f9980e76b1a
+braintrust_app_url = https://www.braintrust.dev

--- a/config/app.config.ini
+++ b/config/app.config.ini
@@ -48,6 +48,6 @@ distance_threshold = 0.30
 keywords_file = config/search_keywords.json
 
 [observability]
-braintrust_enabled = true
+braintrust_enabled = false
 braintrust_project_id = 4e61341a-cc9a-4ce4-a107-4f9980e76b1a
 braintrust_app_url = https://www.braintrust.dev

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ pytest-cov
 ruff
 pre-commit
 openai~=1.78.1
+braintrust~=0.9.0
 requests~=2.32.3
 httpx~=0.28.1
 psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ attrs==25.4.0
     # via
     #   jsonschema
     #   referencing
+braintrust==0.9.0
+    # via -r requirements.in
 certifi==2026.2.25
     # via
     #   httpcore
@@ -22,6 +24,8 @@ cfgv==3.5.0
     # via pre-commit
 charset-normalizer==3.4.6
     # via requests
+chevron==0.14.0
+    # via braintrust
 click==8.3.1
     # via uvicorn
 coverage==7.13.4
@@ -30,6 +34,8 @@ distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via openai
+exceptiongroup==1.3.1
+    # via braintrust
 execnet==2.1.2
     # via pytest-xdist
 fastapi==0.135.1
@@ -38,6 +44,10 @@ filelock==3.25.2
     # via
     #   python-discovery
     #   virtualenv
+gitdb==4.0.12
+    # via gitpython
+gitpython==3.1.46
+    # via braintrust
 h11==0.16.0
     # via
     #   httpcore
@@ -132,7 +142,10 @@ python-discovery==1.1.3
 python-dotenv==1.2.2
     # via
     #   -r requirements.in
+    #   braintrust
     #   pydantic-settings
+python-slugify==8.0.4
+    # via braintrust
 pyyaml==6.0.3
     # via
     #   jsonschema-path
@@ -144,7 +157,9 @@ referencing==0.37.0
     #   jsonschema-specifications
     #   openapi-schema-validator
 requests==2.32.5
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   braintrust
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
 rpds-py==0.30.0
@@ -155,15 +170,25 @@ ruff==0.15.6
     # via -r requirements.in
 six==1.17.0
     # via rfc3339-validator
+smmap==5.0.3
+    # via gitdb
 sniffio==1.3.1
     # via openai
+sseclient-py==1.9.0
+    # via braintrust
 starlette==0.52.1
     # via fastapi
+text-unidecode==1.3
+    # via python-slugify
 tqdm==4.67.3
-    # via openai
+    # via
+    #   braintrust
+    #   openai
 typing-extensions==4.15.0
     # via
     #   anyio
+    #   braintrust
+    #   exceptiongroup
     #   fastapi
     #   openai
     #   pydantic
@@ -183,3 +208,5 @@ uvicorn==0.42.0
     # via -r requirements.in
 virtualenv==21.2.0
     # via pre-commit
+wrapt==2.1.2
+    # via braintrust


### PR DESCRIPTION
This PR adds Braintrust tracing infrastructure and config, including project-ID based initialization, startup/shutdown init+flush hooks, and required dependencies/docs. Trace boundaries now use one UUID per API request or the experiment thread UUID for /experiments/threads routes, while HTTP request span emission was removed so tracing focuses on LLM calls. LLM text, streaming, structured-output, and embedding paths are instrumented with root/parent span handling, safe context reset logic, and consistent input/output message payloads, including output logging for interrupted streams. The PR also adds and updates unit tests for middleware trace context, span parenting behavior, and LLM tracing payload formatting.