### PR TITLE
Add experiment draft handoff to new recipe flow

### DIFF
--- a/app/services/llm_generation_service.py
+++ b/app/services/llm_generation_service.py
@@ -510,7 +510,6 @@ def make_llm_call_structured_output_generic(
 
                 choice = completion.choices[0]
                 message = choice.message
-                content = message.content
                 content_text = _extract_structured_content_text(message)
                 logger.info(
                     "Structured output response (attempt %s/%s): %r",

--- a/app/services/llm_generation_service.py
+++ b/app/services/llm_generation_service.py
@@ -129,6 +129,73 @@ def _assistant_output_payload(content: str | None) -> dict[str, list[dict[str, s
     }
 
 
+def _coerce_content_text(content: Any) -> str | None:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (bytes, bytearray)):
+        return content.decode("utf-8", errors="replace")
+    if not isinstance(content, list):
+        return None
+
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            text = part
+        elif isinstance(part, dict):
+            text = part.get("text")
+            if not isinstance(text, str) and isinstance(text, dict):
+                value = text.get("value")
+                text = value if isinstance(value, str) else None
+        else:
+            text = getattr(part, "text", None)
+            if not isinstance(text, str):
+                value = getattr(text, "value", None)
+                text = value if isinstance(value, str) else None
+
+        if isinstance(text, str) and text:
+            parts.append(text)
+
+    if not parts:
+        return None
+    return "".join(parts)
+
+
+def _extract_structured_content_text(message: Any) -> str | None:
+    content_text = _coerce_content_text(getattr(message, "content", None))
+    if content_text is not None:
+        return content_text
+
+    parsed_payload = getattr(message, "parsed", None)
+    if parsed_payload is not None:
+        if isinstance(parsed_payload, BaseModel):
+            parsed_payload = parsed_payload.model_dump()
+        try:
+            return json.dumps(parsed_payload, ensure_ascii=True)
+        except TypeError:
+            return str(parsed_payload)
+
+    function_call = getattr(message, "function_call", None)
+    function_args = getattr(function_call, "arguments", None)
+    if isinstance(function_args, str) and function_args.strip():
+        return function_args
+
+    tool_calls = getattr(message, "tool_calls", None)
+    if isinstance(tool_calls, list):
+        for tool_call in tool_calls:
+            function = getattr(tool_call, "function", None)
+            if function is None and isinstance(tool_call, dict):
+                function = tool_call.get("function")
+
+            arguments = getattr(function, "arguments", None)
+            if arguments is None and isinstance(function, dict):
+                arguments = function.get("arguments")
+
+            if isinstance(arguments, str) and arguments.strip():
+                return arguments
+
+    return None
+
+
 def make_llm_call_text_generation(user_prompt: str, system_prompt: str) -> str:
     model_name = _get_chat_model_name()
     if not model_name:
@@ -444,17 +511,21 @@ def make_llm_call_structured_output_generic(
                 choice = completion.choices[0]
                 message = choice.message
                 content = message.content
+                content_text = _extract_structured_content_text(message)
                 logger.info(
                     "Structured output response (attempt %s/%s): %r",
                     attempt,
                     max_attempts,
-                    content,
+                    content_text,
                 )
 
-                if content is None:
+                if content_text is None:
                     refusal = getattr(message, "refusal", None)
                     finish_reason = getattr(choice, "finish_reason", None)
-                    has_tool_calls = bool(getattr(message, "tool_calls", None))
+                    has_tool_calls = bool(
+                        getattr(message, "tool_calls", None)
+                        or getattr(message, "function_call", None)
+                    )
                     error_parts = ["Model returned no JSON content."]
                     if refusal:
                         error_parts.append(f"Refusal: {refusal}")
@@ -501,40 +572,6 @@ def make_llm_call_structured_output_generic(
                         metrics=usage_metrics,
                     )
                     return None, error_msg
-
-                if not isinstance(content, (str, bytes, bytearray)):
-                    error_msg = (
-                        "Model returned unsupported content type for JSON parsing: "
-                        f"{type(content).__name__}"
-                    )
-                    logger.error(error_msg)
-                    last_error_msg = error_msg
-                    if attempt < max_attempts:
-                        logger.warning(
-                            "Retrying structured output after unsupported content type "
-                            "(attempt %s/%s).",
-                            attempt + 1,
-                            max_attempts,
-                        )
-                        continue
-                    log_span(
-                        span,
-                        output={
-                            "success": False,
-                            "attempt": attempt,
-                            **_assistant_output_payload(str(content)),
-                            "response": str(content),
-                        },
-                        metadata={"cache_hit": False, "error": error_msg},
-                        metrics=usage_metrics,
-                    )
-                    return None, error_msg
-
-                content_text = (
-                    content
-                    if isinstance(content, str)
-                    else content.decode("utf-8", errors="replace")
-                )
 
                 try:
                     response_data = json.loads(content_text)

--- a/app/services/recipe_extractor_impl.py
+++ b/app/services/recipe_extractor_impl.py
@@ -21,6 +21,21 @@ TITLE_SECTION_PREFIXES = (
     "prep time",
     "cook time",
 )
+INSTRUCTION_SECTION_PREFIXES = ("instructions", "directions", "method", "steps")
+INSTRUCTION_SECTION_STOP_PREFIXES = (
+    "ingredients",
+    "servings",
+    "total time",
+    "prep time",
+    "cook time",
+)
+INGREDIENT_METADATA_PREFIXES = (
+    "servings",
+    "total time",
+    "prep time",
+    "cook time",
+    "yield",
+)
 
 
 def _normalize_lines(values: list[str]) -> list[str]:
@@ -46,7 +61,13 @@ def _fallback_title(raw_text: str) -> str:
         if not stripped:
             continue
         lowered = stripped.lower().removesuffix(":")
+        if lowered.startswith("ingredients"):
+            # If input starts at the ingredients section, we do not have a safe
+            # deterministic title and should defer to the LLM extraction path.
+            break
         if any(lowered.startswith(prefix) for prefix in TITLE_SECTION_PREFIXES):
+            continue
+        if re.match(r"^[-*]\s+\S", stripped) or re.match(r"^\d+[.)]\s+\S", stripped):
             continue
         return stripped
     return ""
@@ -54,10 +75,25 @@ def _fallback_title(raw_text: str) -> str:
 
 def _fallback_instructions(raw_text: str) -> list[str]:
     fallback_steps: list[str] = []
+    in_instructions_section = False
+
     for line in raw_text.splitlines():
         stripped = line.strip()
         if not stripped:
             continue
+
+        lowered = stripped.lower().removesuffix(":")
+        if not in_instructions_section:
+            if any(
+                lowered.startswith(prefix) for prefix in INSTRUCTION_SECTION_PREFIXES
+            ):
+                in_instructions_section = True
+            continue
+
+        if any(
+            lowered.startswith(prefix) for prefix in INSTRUCTION_SECTION_STOP_PREFIXES
+        ):
+            break
 
         numbered_step = re.match(r"^\d+[.)]\s*(.+)$", stripped)
         if numbered_step:
@@ -82,15 +118,18 @@ def _fallback_ingredients(raw_text: str) -> list[str]:
             in_ingredients_section = True
             continue
 
-        if in_ingredients_section and (
-            lowered.startswith("instructions")
-            or lowered.startswith("directions")
-            or lowered.startswith("method")
-            or lowered.startswith("steps")
+        if in_ingredients_section and any(
+            lowered.startswith(prefix) for prefix in INSTRUCTION_SECTION_PREFIXES
         ):
             break
 
         if not in_ingredients_section:
+            continue
+
+        if any(
+            lowered == prefix or lowered.startswith(f"{prefix}:")
+            for prefix in INGREDIENT_METADATA_PREFIXES
+        ):
             continue
 
         item = _clean_list_item(stripped)

--- a/app/services/recipe_extractor_impl.py
+++ b/app/services/recipe_extractor_impl.py
@@ -100,6 +100,16 @@ def _fallback_ingredients(raw_text: str) -> list[str]:
     return fallback_items
 
 
+def _fallback_scalar_field(raw_text: str, label: str) -> str:
+    match = re.search(
+        rf"(?im)^\s*{re.escape(label)}\s*:\s*(.+?)\s*$",
+        raw_text,
+    )
+    if not match:
+        return ""
+    return match.group(1).strip()
+
+
 def _fallback_recipe(raw_text: str) -> Optional[Recipe]:
     title = _fallback_title(raw_text)
     ingredients = _fallback_ingredients(raw_text)
@@ -113,8 +123,8 @@ def _fallback_recipe(raw_text: str) -> Optional[Recipe]:
         title=title,
         ingredients=ingredients,
         instructions=instructions,
-        servings="",
-        total_time="",
+        servings=_fallback_scalar_field(raw_text, "servings"),
+        total_time=_fallback_scalar_field(raw_text, "total time"),
     )
 
 
@@ -139,6 +149,13 @@ class RecipeExtractorImpl:
         """
         if not raw_text or not raw_text.strip():
             return None, "Input text is empty or contains only whitespace"
+
+        fallback_recipe = _fallback_recipe(raw_text)
+        if fallback_recipe:
+            logger.info(
+                "Using deterministic parser for structured recipe input; skipping LLM extraction."
+            )
+            return fallback_recipe, None
 
         # Use the LLM to extract structured recipe data
         result, error = make_llm_call_structured_output_generic(

--- a/app/services/recipe_extractor_impl.py
+++ b/app/services/recipe_extractor_impl.py
@@ -100,6 +100,24 @@ def _fallback_ingredients(raw_text: str) -> list[str]:
     return fallback_items
 
 
+def _fallback_recipe(raw_text: str) -> Optional[Recipe]:
+    title = _fallback_title(raw_text)
+    ingredients = _fallback_ingredients(raw_text)
+    instructions = _fallback_instructions(raw_text)
+
+    # Only accept deterministic fallback when we can recover core recipe sections.
+    if not title or not ingredients or not instructions:
+        return None
+
+    return Recipe(
+        title=title,
+        ingredients=ingredients,
+        instructions=instructions,
+        servings="",
+        total_time="",
+    )
+
+
 class RecipeExtractorImpl:
     """
     LLM-backed extractor for structured recipe data from raw text input.
@@ -131,6 +149,13 @@ class RecipeExtractorImpl:
         )
 
         if error or not result:
+            fallback_recipe = _fallback_recipe(raw_text)
+            if fallback_recipe:
+                logger.warning(
+                    "LLM extraction failed; using deterministic fallback parser. error=%s",
+                    error,
+                )
+                return fallback_recipe, None
             return result, error
 
         title = result.title.strip()

--- a/app/services/recipe_processing_service.py
+++ b/app/services/recipe_processing_service.py
@@ -1,6 +1,7 @@
 from html.parser import HTMLParser
 import ipaddress
 import os
+import re
 import socket
 from typing import Optional
 from urllib.parse import urljoin, urlsplit
@@ -35,6 +36,13 @@ URL_FETCH_DOMAIN_ALLOWLIST = tuple(
 )
 URL_FETCH_REDIRECT_STATUS_CODES = frozenset({301, 302, 303, 307, 308})
 MAX_EXTRACTED_TEXT_CHARS = 25000
+RECIPE_SECTION_LINE_RE = re.compile(
+    r"(?im)^\s*ingredients\s*:.*^\s*(instructions|directions|method|steps)\s*:",
+    re.MULTILINE | re.DOTALL,
+)
+RECIPE_BULLET_LINE_RE = re.compile(r"(?m)^\s*[-*]\s+\S")
+RECIPE_NUMBERED_STEP_RE = re.compile(r"(?m)^\s*\d+[.)]\s+\S")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
 HTML_IGNORED_TAGS = {
     "script",
     "style",
@@ -451,16 +459,36 @@ class RecipeProcessingService:
         Returns:
             Cleaned text or None if cleanup failed
         """
+        normalized_input = (raw_input or "").strip()
+        if not normalized_input:
+            return None
+        if self._looks_like_structured_recipe_text(normalized_input):
+            logger.info("Skipping LLM cleanup for structured recipe-style input.")
+            return normalized_input
+
         try:
-            cleaned_text = self.cleanup_service.cleanup_input(raw_input)
+            cleaned_text = self.cleanup_service.cleanup_input(normalized_input)
             logger.info(
-                f"Input cleanup completed. Original length: {len(raw_input)}, "
+                f"Input cleanup completed. Original length: {len(normalized_input)}, "
                 f"Cleaned length: {len(cleaned_text)}"
             )
             return cleaned_text
         except Exception as e:
             logger.error(f"Input cleanup failed: {e}")
             return None
+
+    @staticmethod
+    def _looks_like_structured_recipe_text(raw_input: str) -> bool:
+        # Avoid skipping cleanup for raw HTML payloads.
+        if HTML_TAG_RE.search(raw_input):
+            return False
+
+        if RECIPE_SECTION_LINE_RE.search(raw_input):
+            return True
+
+        bullet_matches = RECIPE_BULLET_LINE_RE.findall(raw_input)
+        numbered_step_matches = RECIPE_NUMBERED_STEP_RE.findall(raw_input)
+        return len(bullet_matches) >= 2 and len(numbered_step_matches) >= 2
 
     def _extract_recipe(
         self, cleaned_text: str

--- a/app/tests/unit/test_llm_generation_service_structured_output.py
+++ b/app/tests/unit/test_llm_generation_service_structured_output.py
@@ -269,7 +269,9 @@ def test_structured_output_accepts_function_arguments_when_content_missing(
         responses=[
             {
                 "content": None,
-                "function_call": SimpleNamespace(arguments='{"ingredients":["1 tomato"]}'),
+                "function_call": SimpleNamespace(
+                    arguments='{"ingredients":["1 tomato"]}'
+                ),
             }
         ]
     )

--- a/app/tests/unit/test_llm_generation_service_structured_output.py
+++ b/app/tests/unit/test_llm_generation_service_structured_output.py
@@ -47,6 +47,10 @@ class _SequenceStructuredCompletions:
         response = self._responses[index]
 
         message = SimpleNamespace(content=response.get("content"))
+        parsed = response.get("parsed")
+        if parsed is not None:
+            message.parsed = parsed
+
         refusal = response.get("refusal")
         if refusal is not None:
             message.refusal = refusal
@@ -54,6 +58,10 @@ class _SequenceStructuredCompletions:
         tool_calls = response.get("tool_calls")
         if tool_calls is not None:
             message.tool_calls = tool_calls
+
+        function_call = response.get("function_call")
+        if function_call is not None:
+            message.function_call = function_call
 
         finish_reason = response.get("finish_reason", "stop")
         choice = SimpleNamespace(message=message, finish_reason=finish_reason)
@@ -223,3 +231,66 @@ def test_structured_output_logs_assistant_message_payload(monkeypatch) -> None:
     final_output = log_events[-1]["output"]
     assert final_output["messages"][0]["role"] == "assistant"
     assert final_output["messages"][0]["content"] == '{"ingredients":["1 tomato"]}'
+
+
+def test_structured_output_accepts_parsed_payload_when_content_missing(
+    monkeypatch,
+) -> None:
+    fake_completions = _SequenceStructuredCompletions(
+        responses=[{"content": None, "parsed": {"ingredients": ["1 tomato"]}}]
+    )
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=fake_completions))
+    cache = TTLCache[dict](ttl_seconds=60, max_items=10)
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
+
+    suffix = uuid4().hex
+    result, error = llm_generation_service.make_llm_call_structured_output_generic(
+        user_prompt=f"user-prompt-{suffix}",
+        system_prompt=f"system-prompt-{suffix}",
+        model_class=_StructuredResponseModel,
+        schema_name="structured_output_parsed_payload_test",
+    )
+
+    assert error is None
+    assert result is not None
+    assert result.ingredients == ["1 tomato"]
+    assert fake_completions.calls == 1
+
+
+def test_structured_output_accepts_function_arguments_when_content_missing(
+    monkeypatch,
+) -> None:
+    fake_completions = _SequenceStructuredCompletions(
+        responses=[
+            {
+                "content": None,
+                "function_call": SimpleNamespace(arguments='{"ingredients":["1 tomato"]}'),
+            }
+        ]
+    )
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=fake_completions))
+    cache = TTLCache[dict](ttl_seconds=60, max_items=10)
+
+    monkeypatch.setattr(llm_generation_service, "_get_chat_model_name", lambda: "test")
+    monkeypatch.setattr(
+        llm_generation_service, "_get_openai_client", lambda: fake_client
+    )
+    monkeypatch.setattr(llm_generation_service, "llm_structured_cache", cache)
+
+    suffix = uuid4().hex
+    result, error = llm_generation_service.make_llm_call_structured_output_generic(
+        user_prompt=f"user-prompt-{suffix}",
+        system_prompt=f"system-prompt-{suffix}",
+        model_class=_StructuredResponseModel,
+        schema_name="structured_output_function_arguments_test",
+    )
+
+    assert error is None
+    assert result is not None
+    assert result.ingredients == ["1 tomato"]
+    assert fake_completions.calls == 1

--- a/app/tests/unit/test_recipe_extractor_impl.py
+++ b/app/tests/unit/test_recipe_extractor_impl.py
@@ -120,3 +120,97 @@ def test_extract_recipe_keeps_error_when_fallback_has_no_recipe_sections(
 
     assert recipe is None
     assert error == "Model returned no JSON content. finish_reason=stop"
+
+
+def test_extract_recipe_calls_llm_when_structured_input_has_no_title(
+    monkeypatch,
+) -> None:
+    raw_text = (
+        "Ingredients:\n- 2 eggs\n- 1 tbsp butter\n"
+        "Instructions:\n1. Beat eggs.\n2. Cook eggs.\n"
+    )
+    calls = {"count": 0}
+
+    def fake_llm_call(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        calls["count"] += 1
+        return (
+            Recipe(
+                title="Generated Omelet",
+                ingredients=["2 eggs", "1 tbsp butter"],
+                instructions=["Beat eggs.", "Cook eggs."],
+                servings="1",
+                total_time="8 minutes",
+            ),
+            None,
+        )
+
+    monkeypatch.setattr(
+        recipe_extractor_impl,
+        "make_llm_call_structured_output_generic",
+        fake_llm_call,
+    )
+
+    recipe, error = RecipeExtractorImpl().extract_recipe_from_raw_text(raw_text)
+
+    assert error is None
+    assert recipe is not None
+    assert calls["count"] == 1
+    assert recipe.title == "Generated Omelet"
+
+
+def test_extract_recipe_fallback_ignores_metadata_lines_in_ingredients(
+    monkeypatch,
+) -> None:
+    raw_text = (
+        "Simple Soup\n"
+        "Ingredients:\n- 1 cup water\nServings: 2\nTotal time: 10 minutes\n- Salt\n"
+        "Instructions:\n1. Boil water.\n2. Add salt.\n"
+    )
+
+    def fake_llm_call(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        return None, "Model returned no JSON content. finish_reason=stop"
+
+    monkeypatch.setattr(
+        recipe_extractor_impl,
+        "make_llm_call_structured_output_generic",
+        fake_llm_call,
+    )
+
+    recipe, error = RecipeExtractorImpl().extract_recipe_from_raw_text(raw_text)
+
+    assert error is None
+    assert recipe is not None
+    assert recipe.title == "Simple Soup"
+    assert recipe.ingredients == ["1 cup water", "Salt"]
+    assert recipe.servings == "2"
+    assert recipe.total_time == "10 minutes"
+
+
+def test_extract_recipe_fallback_ignores_numbered_ingredients_for_instructions(
+    monkeypatch,
+) -> None:
+    raw_text = (
+        "Simple Pasta\n"
+        "Ingredients:\n1. 200g pasta\n2. 1 cup tomato sauce\n"
+        "Instructions:\n1. Boil pasta\n2. Add sauce\n"
+    )
+
+    def fake_llm_call(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        raise AssertionError("deterministic fallback should bypass LLM call")
+
+    monkeypatch.setattr(
+        recipe_extractor_impl,
+        "make_llm_call_structured_output_generic",
+        fake_llm_call,
+    )
+
+    recipe, error = RecipeExtractorImpl().extract_recipe_from_raw_text(raw_text)
+
+    assert error is None
+    assert recipe is not None
+    assert recipe.title == "Simple Pasta"
+    assert recipe.ingredients == ["200g pasta", "1 cup tomato sauce"]
+    assert recipe.instructions == ["Boil pasta", "Add sauce"]

--- a/app/tests/unit/test_recipe_extractor_impl.py
+++ b/app/tests/unit/test_recipe_extractor_impl.py
@@ -73,3 +73,50 @@ def test_extract_recipe_backfills_missing_ingredients(monkeypatch) -> None:
     assert error is None
     assert recipe is not None
     assert recipe.ingredients == ["2 eggs", "1 tbsp butter", "Salt"]
+
+
+def test_extract_recipe_uses_deterministic_fallback_on_llm_failure(monkeypatch) -> None:
+    raw_text = (
+        "Simple Pasta\n"
+        "Ingredients:\n- 200g pasta\n- 1 cup tomato sauce\n"
+        "Instructions:\n1. Boil pasta\n2. Add sauce\n"
+    )
+
+    def fake_llm_call(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        return None, "Model returned no JSON content. finish_reason=stop"
+
+    monkeypatch.setattr(
+        recipe_extractor_impl,
+        "make_llm_call_structured_output_generic",
+        fake_llm_call,
+    )
+
+    recipe, error = RecipeExtractorImpl().extract_recipe_from_raw_text(raw_text)
+
+    assert error is None
+    assert recipe is not None
+    assert recipe.title == "Simple Pasta"
+    assert recipe.ingredients == ["200g pasta", "1 cup tomato sauce"]
+    assert recipe.instructions == ["Boil pasta", "Add sauce"]
+
+
+def test_extract_recipe_keeps_error_when_fallback_has_no_recipe_sections(
+    monkeypatch,
+) -> None:
+    raw_text = "This is not a recipe."
+
+    def fake_llm_call(*args, **kwargs):  # noqa: ANN002, ANN003
+        del args, kwargs
+        return None, "Model returned no JSON content. finish_reason=stop"
+
+    monkeypatch.setattr(
+        recipe_extractor_impl,
+        "make_llm_call_structured_output_generic",
+        fake_llm_call,
+    )
+
+    recipe, error = RecipeExtractorImpl().extract_recipe_from_raw_text(raw_text)
+
+    assert recipe is None
+    assert error == "Model returned no JSON content. finish_reason=stop"

--- a/app/tests/unit/test_recipe_processing_service_preview.py
+++ b/app/tests/unit/test_recipe_processing_service_preview.py
@@ -45,6 +45,58 @@ class PreviewServiceHarness(RecipeProcessingService):
         return self._html
 
 
+def test_cleanup_input_skips_llm_for_structured_recipe_text() -> None:
+    class FailingCleanupService:
+        def cleanup_input(self, messy_input: str) -> str:
+            del messy_input
+            raise AssertionError(
+                "cleanup_input should not be called for structured text"
+            )
+
+    service = RecipeProcessingService(
+        cleanup_service=FailingCleanupService(),
+        extractor_service=MarkerRecipeExtractor(),
+        recipe_manager=object(),
+        embeddings_service=object(),
+        dedupe_service=object(),
+    )
+
+    cleaned = service._cleanup_input(
+        "Simple Pasta\n\nIngredients:\n- 200g pasta\n- 1 cup tomato sauce\n\n"
+        "Instructions:\n1. Boil pasta\n2. Add sauce\n"
+    )
+
+    assert cleaned is not None
+    assert "Simple Pasta" in cleaned
+
+
+def test_cleanup_input_uses_cleanup_service_for_html_payload() -> None:
+    class RecordingCleanupService:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def cleanup_input(self, messy_input: str) -> str:
+            self.calls += 1
+            return f"CLEANED::{messy_input[:20]}"
+
+    cleanup_service = RecordingCleanupService()
+    service = RecipeProcessingService(
+        cleanup_service=cleanup_service,
+        extractor_service=MarkerRecipeExtractor(),
+        recipe_manager=object(),
+        embeddings_service=object(),
+        dedupe_service=object(),
+    )
+
+    cleaned = service._cleanup_input(
+        "<div>Simple Pasta</div><div>Ingredients: pasta</div><div>Instructions: boil</div>"
+    )
+
+    assert cleanup_service.calls == 1
+    assert cleaned is not None
+    assert cleaned.startswith("CLEANED::")
+
+
 def test_preview_fails_when_recipe_is_beyond_max_context_window() -> None:
     long_noise = "noise " * 6000
     html = (

--- a/apps/web/src/app/experiment/page.test.tsx
+++ b/apps/web/src/app/experiment/page.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY } from "@/lib/experiment-recipe-draft";
+
 import ExperimentPage from "./page";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -38,6 +40,7 @@ function toUrl(input: RequestInfo | URL): string {
 describe("/experiment page", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    window.sessionStorage.clear();
   });
 
   it("starts a new thread from sidebar and renders active conversation", async () => {
@@ -596,5 +599,130 @@ describe("/experiment page", () => {
       toUrl(input).startsWith("/api/experiments/threads/thread-1?"),
     );
     expect(reloadCalls).toHaveLength(0);
+  });
+
+  it("stores latest assistant output before opening Add Recipe flow", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = toUrl(input);
+      if (url.startsWith("/api/experiments/threads?")) {
+        return jsonResponse({ success: true, count: 0, threads: [] });
+      }
+      if (url === "/api/experiments/threads" && init?.method === "POST") {
+        return jsonResponse({
+          success: true,
+          thread: {
+            id: "thread-draft",
+            mode: "invent_new",
+            title: null,
+            metadata: {},
+            context_recipe_ids: [],
+            messages: [],
+            created_at: null,
+            updated_at: null,
+          },
+        });
+      }
+      if (
+        url === "/api/experiments/threads/thread-draft/messages/stream" &&
+        init?.method === "POST"
+      ) {
+        const assistantContent = [
+          "Lemon Garlic Chicken",
+          "",
+          "Ingredients:",
+          "- 1 lb chicken thighs",
+          "- 2 tbsp olive oil",
+          "",
+          "Instructions:",
+          "1. Season the chicken.",
+          "2. Sear and finish in the oven.",
+        ].join("\n");
+        const finalPayload = {
+          thread_id: "thread-draft",
+          thread: {
+            id: "thread-draft",
+            mode: "invent_new",
+            title: "Recipe draft",
+            metadata: {},
+            context_recipe_ids: [],
+            messages: [
+              {
+                id: "msg-user",
+                thread_id: "thread-draft",
+                sequence_no: 1,
+                role: "user",
+                content: "Give me a complete recipe draft",
+                tool_name: null,
+                tool_call: null,
+                created_at: null,
+              },
+              {
+                id: "msg-assistant",
+                thread_id: "thread-draft",
+                sequence_no: 2,
+                role: "assistant",
+                content: assistantContent,
+                tool_name: null,
+                tool_call: null,
+                created_at: null,
+              },
+            ],
+            created_at: null,
+            updated_at: null,
+          },
+          user_message: {
+            id: "msg-user",
+            thread_id: "thread-draft",
+            sequence_no: 1,
+            role: "user",
+            content: "Give me a complete recipe draft",
+            tool_name: null,
+            tool_call: null,
+            created_at: null,
+          },
+          assistant_message: {
+            id: "msg-assistant",
+            thread_id: "thread-draft",
+            sequence_no: 2,
+            role: "assistant",
+            content: assistantContent,
+            tool_name: null,
+            tool_call: null,
+            created_at: null,
+          },
+          attachment_message: null,
+          attached_recipes: [],
+          unresolved_recipe_names: [],
+          success: true,
+        };
+        return sseResponse(`event: final\ndata: ${JSON.stringify(finalPayload)}\n\n`);
+      }
+      return jsonResponse({ detail: "Not found" }, 404);
+    });
+
+    const user = userEvent.setup();
+    render(<ExperimentPage />);
+
+    await user.type(screen.getByLabelText("Your message"), "Give me a complete recipe draft");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    const addAsRecipeLink = await screen.findByRole("link", { name: "Add As Recipe" });
+    addAsRecipeLink.addEventListener("click", (event) => event.preventDefault());
+    await user.click(addAsRecipeLink);
+
+    expect(window.sessionStorage.getItem(EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY)).toBe(
+      [
+        "Lemon Garlic Chicken",
+        "",
+        "Ingredients:",
+        "- 1 lb chicken thighs",
+        "- 2 tbsp olive oil",
+        "",
+        "Instructions:",
+        "1. Season the chicken.",
+        "2. Sear and finish in the oven.",
+      ].join("\n"),
+    );
   });
 });

--- a/apps/web/src/app/experiment/page.test.tsx
+++ b/apps/web/src/app/experiment/page.test.tsx
@@ -4,6 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY } from "@/lib/experiment-recipe-draft";
 
+const { mockRouterPush } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
+}));
+
+vi.mock("next/navigation", async () => {
+  const actual =
+    await vi.importActual<typeof import("next/navigation")>("next/navigation");
+  return {
+    ...actual,
+    usePathname: () => "/",
+    useRouter: () => ({
+      push: mockRouterPush,
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+    }),
+  };
+});
+
 import ExperimentPage from "./page";
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -41,6 +62,7 @@ describe("/experiment page", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
     window.sessionStorage.clear();
+    mockRouterPush.mockReset();
   });
 
   it("starts a new thread from sidebar and renders active conversation", async () => {
@@ -707,9 +729,8 @@ describe("/experiment page", () => {
     await user.type(screen.getByLabelText("Your message"), "Give me a complete recipe draft");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    const addAsRecipeLink = await screen.findByRole("link", { name: "Add As Recipe" });
-    addAsRecipeLink.addEventListener("click", (event) => event.preventDefault());
-    await user.click(addAsRecipeLink);
+    const addAsRecipeButton = await screen.findByRole("button", { name: "Add As Recipe" });
+    await user.click(addAsRecipeButton);
 
     expect(window.sessionStorage.getItem(EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY)).toBe(
       [
@@ -724,5 +745,171 @@ describe("/experiment page", () => {
         "2. Sear and finish in the oven.",
       ].join("\n"),
     );
+    expect(mockRouterPush).toHaveBeenCalledWith("/recipes/new");
+  });
+
+  it("keeps Add As Recipe disabled while a message is sending", async () => {
+    const fetchMock = vi.mocked(fetch);
+    let releaseStream: (() => void) | null = null;
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = toUrl(input);
+      if (url.startsWith("/api/experiments/threads?")) {
+        return jsonResponse({
+          success: true,
+          count: 1,
+          threads: [
+            {
+              id: "thread-existing",
+              mode: "invent_new",
+              title: "Existing draft",
+              metadata: {},
+              created_at: null,
+              updated_at: null,
+              last_message_role: "assistant",
+              last_message_content: "Current draft from history.",
+              last_message_created_at: null,
+            },
+          ],
+        });
+      }
+      if (url === "/api/experiments/threads/thread-existing?message_limit=120") {
+        return jsonResponse({
+          success: true,
+          thread: {
+            id: "thread-existing",
+            mode: "invent_new",
+            title: "Existing draft",
+            metadata: {},
+            context_recipe_ids: [],
+            messages: [
+              {
+                id: "msg-assistant-existing",
+                thread_id: "thread-existing",
+                sequence_no: 1,
+                role: "assistant",
+                content: "Current draft from history.",
+                tool_name: null,
+                tool_call: null,
+                created_at: null,
+              },
+            ],
+            created_at: null,
+            updated_at: null,
+          },
+        });
+      }
+      if (
+        url === "/api/experiments/threads/thread-existing/messages/stream" &&
+        init?.method === "POST"
+      ) {
+        const finalPayload = {
+          thread_id: "thread-existing",
+          thread: {
+            id: "thread-existing",
+            mode: "invent_new",
+            title: "Existing draft",
+            metadata: {},
+            context_recipe_ids: [],
+            messages: [
+              {
+                id: "msg-assistant-existing",
+                thread_id: "thread-existing",
+                sequence_no: 1,
+                role: "assistant",
+                content: "Current draft from history.",
+                tool_name: null,
+                tool_call: null,
+                created_at: null,
+              },
+              {
+                id: "msg-user-new",
+                thread_id: "thread-existing",
+                sequence_no: 2,
+                role: "user",
+                content: "Keep working this draft",
+                tool_name: null,
+                tool_call: null,
+                created_at: null,
+              },
+              {
+                id: "msg-assistant-new",
+                thread_id: "thread-existing",
+                sequence_no: 3,
+                role: "assistant",
+                content: "Updated draft after send.",
+                tool_name: null,
+                tool_call: null,
+                created_at: null,
+              },
+            ],
+            created_at: null,
+            updated_at: null,
+          },
+          user_message: {
+            id: "msg-user-new",
+            thread_id: "thread-existing",
+            sequence_no: 2,
+            role: "user",
+            content: "Keep working this draft",
+            tool_name: null,
+            tool_call: null,
+            created_at: null,
+          },
+          assistant_message: {
+            id: "msg-assistant-new",
+            thread_id: "thread-existing",
+            sequence_no: 3,
+            role: "assistant",
+            content: "Updated draft after send.",
+            tool_name: null,
+            tool_call: null,
+            created_at: null,
+          },
+          attachment_message: null,
+          attached_recipes: [],
+          unresolved_recipe_names: [],
+          success: true,
+        };
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode('event: status\ndata: {"step":"drafting"}\n\n'));
+            releaseStream = () => {
+              controller.enqueue(
+                encoder.encode(`event: final\ndata: ${JSON.stringify(finalPayload)}\n\n`),
+              );
+              controller.close();
+            };
+          },
+        });
+        return new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return jsonResponse({ detail: "Not found" }, 404);
+    });
+
+    const user = userEvent.setup();
+    render(<ExperimentPage />);
+
+    await user.click(await screen.findByRole("button", { name: /Existing draft/i }));
+    const historyDraftMatches = await screen.findAllByText("Current draft from history.");
+    expect(historyDraftMatches.length).toBeGreaterThan(1);
+
+    await user.type(screen.getByLabelText("Your message"), "Keep working this draft");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    const addAsRecipeButton = await screen.findByRole("button", { name: "Add As Recipe" });
+    expect(addAsRecipeButton).toBeDisabled();
+    await user.click(addAsRecipeButton);
+
+    expect(window.sessionStorage.getItem(EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY)).toBeNull();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    expect(releaseStream).not.toBeNull();
+    releaseStream?.();
+    const updatedDraftMatches = await screen.findAllByText("Updated draft after send.");
+    expect(updatedDraftMatches.length).toBeGreaterThan(1);
   });
 });

--- a/apps/web/src/app/experiment/page.tsx
+++ b/apps/web/src/app/experiment/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { History, Loader2, Paperclip, Plus, Send, Sparkles, X } from "lucide-react";
-import { type FormEvent, type MouseEvent, type ReactNode, useEffect, useRef, useState } from "react";
+import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -329,6 +329,7 @@ function renderMessageContent(
 }
 
 export default function ExperimentPage() {
+  const router = useRouter();
   const [messageInput, setMessageInput] = useState("");
   const [thread, setThread] = useState<ExperimentThreadRecord | null>(null);
   const [threadHistory, setThreadHistory] = useState<ExperimentThreadSummary[]>([]);
@@ -775,13 +776,16 @@ export default function ExperimentPage() {
       .find((message) => message.role === "assistant" && message.content.trim().length > 0) ??
     null;
 
-  function handleOpenAddRecipeFlow(event: MouseEvent<HTMLAnchorElement>) {
+  function handleOpenAddRecipeFlow() {
+    if (isBusy) {
+      return;
+    }
     if (!latestAssistantMessage || !saveExperimentRecipeDraft(latestAssistantMessage.content)) {
-      event.preventDefault();
       setErrorMessage("Unable to transfer the latest assistant draft to Add Recipe.");
       return;
     }
     setErrorMessage(null);
+    router.push("/recipes/new");
   }
 
   return (
@@ -1153,11 +1157,14 @@ export default function ExperimentPage() {
 
                   <div className="flex items-center gap-2">
                     {latestAssistantMessage ? (
-                      <Button asChild type="button" variant="secondary" disabled={isBusy}>
-                        <Link href="/recipes/new" onClick={handleOpenAddRecipeFlow}>
-                          <Sparkles className="size-4" />
-                          Add As Recipe
-                        </Link>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        disabled={isBusy}
+                        onClick={handleOpenAddRecipeFlow}
+                      >
+                        <Sparkles className="size-4" />
+                        Add As Recipe
                       </Button>
                     ) : null}
 

--- a/apps/web/src/app/experiment/page.tsx
+++ b/apps/web/src/app/experiment/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import Link from "next/link";
 import { History, Loader2, Paperclip, Plus, Send, Sparkles, X } from "lucide-react";
-import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
+import { type FormEvent, type MouseEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -21,6 +22,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { saveExperimentRecipeDraft } from "@/lib/experiment-recipe-draft";
 import type {
   CreateExperimentMessageResponse,
   CreateExperimentThreadResponse,
@@ -767,12 +769,26 @@ export default function ExperimentPage() {
 
   const isBusy = isCreatingThread || isLoadingThread || isSendingMessage;
   const normalizedAttachQuery = attachSearchInput.trim();
+  const latestAssistantMessage =
+    [...(thread?.messages ?? [])]
+      .reverse()
+      .find((message) => message.role === "assistant" && message.content.trim().length > 0) ??
+    null;
+
+  function handleOpenAddRecipeFlow(event: MouseEvent<HTMLAnchorElement>) {
+    if (!latestAssistantMessage || !saveExperimentRecipeDraft(latestAssistantMessage.content)) {
+      event.preventDefault();
+      setErrorMessage("Unable to transfer the latest assistant draft to Add Recipe.");
+      return;
+    }
+    setErrorMessage(null);
+  }
 
   return (
     <div className="min-h-screen">
       <ForkfolioHeader />
 
-      <main className="mx-auto w-full max-w-7xl space-y-6 px-4 py-8 sm:px-6 sm:py-10">
+      <main className="mx-auto w-full max-w-[1500px] space-y-6 px-4 py-8 sm:px-6 sm:py-10">
         <section className="space-y-2">
           <Badge className="rounded-full px-3 py-0.5">Experiment</Badge>
           <h1 className="font-display text-4xl leading-tight sm:text-5xl">
@@ -783,8 +799,8 @@ export default function ExperimentPage() {
           </p>
         </section>
 
-        <section className="grid gap-6 lg:grid-cols-[280px_1fr]">
-          <Card className="h-[75vh]">
+        <section className="grid gap-6 lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[260px_minmax(0,1fr)]">
+          <Card className="h-[82vh]">
             <CardHeader className="space-y-3">
               <CardTitle className="flex items-center gap-2 text-xl">
                 <History className="size-4 text-primary" />
@@ -804,7 +820,7 @@ export default function ExperimentPage() {
                 )}
               </Button>
             </CardHeader>
-            <CardContent className="h-[calc(75vh-8rem)] space-y-2 overflow-y-auto">
+            <CardContent className="h-[calc(82vh-8rem)] space-y-2 overflow-y-auto">
               {isLoadingHistory ? (
                 <p className="text-sm text-muted-foreground">Loading…</p>
               ) : threadHistory.length === 0 ? (
@@ -834,7 +850,7 @@ export default function ExperimentPage() {
             </CardContent>
           </Card>
 
-          <Card className="h-[75vh] overflow-hidden">
+          <Card className="h-[82vh] overflow-hidden">
             <CardHeader>
               <CardTitle>
                 {thread
@@ -847,7 +863,7 @@ export default function ExperimentPage() {
                   : "Type a message to start instantly, or use New Thread."}
               </CardDescription>
             </CardHeader>
-            <CardContent className="flex h-[calc(75vh-7.5rem)] min-h-0 flex-col gap-4">
+            <CardContent className="flex h-[calc(82vh-7.5rem)] min-h-0 flex-col gap-4">
               {errorMessage ? (
                 <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                   {errorMessage}
@@ -1135,19 +1151,30 @@ export default function ExperimentPage() {
                     </DialogContent>
                   </Dialog>
 
-                  <Button type="submit" disabled={!canSendMessage}>
-                    {isSendingMessage ? (
-                      <>
-                        <Loader2 className="size-4 animate-spin" />
-                        Sending…
-                      </>
-                    ) : (
-                      <>
-                        <Send className="size-4" />
-                        Send
-                      </>
-                    )}
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    {latestAssistantMessage ? (
+                      <Button asChild type="button" variant="secondary" disabled={isBusy}>
+                        <Link href="/recipes/new" onClick={handleOpenAddRecipeFlow}>
+                          <Sparkles className="size-4" />
+                          Add As Recipe
+                        </Link>
+                      </Button>
+                    ) : null}
+
+                    <Button type="submit" disabled={!canSendMessage}>
+                      {isSendingMessage ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" />
+                          Sending…
+                        </>
+                      ) : (
+                        <>
+                          <Send className="size-4" />
+                          Send
+                        </>
+                      )}
+                    </Button>
+                  </div>
                 </div>
               </form>
             </CardContent>

--- a/apps/web/src/app/recipes/new/page.test.tsx
+++ b/apps/web/src/app/recipes/new/page.test.tsx
@@ -2,11 +2,50 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY } from "@/lib/experiment-recipe-draft";
+
 import NewRecipePage from "./page";
 
 describe("/recipes/new page", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    window.sessionStorage.clear();
+  });
+
+  it("hydrates raw recipe text from experiment draft storage", async () => {
+    window.sessionStorage.setItem(
+      EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY,
+      [
+        "Skillet Lemon Rice",
+        "",
+        "Ingredients:",
+        "- 1 cup rice",
+        "- 2 cups broth",
+        "",
+        "Instructions:",
+        "1. Toast rice.",
+        "2. Simmer until tender.",
+      ].join("\n"),
+    );
+
+    render(<NewRecipePage />);
+
+    const textTab = await screen.findByRole("tab", { name: /Paste Text/i });
+    expect(textTab).toHaveAttribute("data-state", "active");
+    expect(screen.getByLabelText("Raw recipe text")).toHaveValue(
+      [
+        "Skillet Lemon Rice",
+        "",
+        "Ingredients:",
+        "- 1 cup rice",
+        "- 2 cups broth",
+        "",
+        "Instructions:",
+        "1. Toast rice.",
+        "2. Simmer until tender.",
+      ].join("\n"),
+    );
+    expect(window.sessionStorage.getItem(EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY)).toBeNull();
   });
 
   it("disables submit while input is too short", async () => {

--- a/apps/web/src/app/recipes/new/page.tsx
+++ b/apps/web/src/app/recipes/new/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ArrowRight, Loader2, Sparkles } from "lucide-react";
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
 import { PageBackLink, PageHero, PageMain, PageShell } from "@/components/page-shell";
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { consumeExperimentRecipeDraft } from "@/lib/experiment-recipe-draft";
 import {
   MIN_RECIPE_INPUT_LENGTH,
   type PreviewRecipeFromUrlResponse,
@@ -211,6 +212,20 @@ export default function NewRecipePage() {
     null,
   );
   const [result, setResult] = useState<ProcessRecipeResponse | null>(null);
+
+  useEffect(() => {
+    const experimentDraft = consumeExperimentRecipeDraft();
+    if (!experimentDraft) {
+      return;
+    }
+    setRawInput(experimentDraft);
+    setInputMode("text");
+    setSourceUrl("");
+    setTextModeSourceUrl(null);
+    setPreviewResult(null);
+    setPreviewErrorMessage(null);
+    setErrorMessage(null);
+  }, []);
 
   const trimmedLength = useMemo(() => rawInput.trim().length, [rawInput]);
   const normalizedSourceUrl = useMemo(() => sourceUrl.trim(), [sourceUrl]);

--- a/apps/web/src/lib/experiment-recipe-draft.ts
+++ b/apps/web/src/lib/experiment-recipe-draft.ts
@@ -1,0 +1,35 @@
+export const EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY = "forkfolio:experiment-recipe-draft";
+
+export function saveExperimentRecipeDraft(content: string): boolean {
+  const normalizedContent = content.trim();
+  if (!normalizedContent || typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    window.sessionStorage.setItem(
+      EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY,
+      normalizedContent,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function consumeExperimentRecipeDraft(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const storedContent = window.sessionStorage.getItem(
+      EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY,
+    );
+    window.sessionStorage.removeItem(EXPERIMENT_RECIPE_DRAFT_STORAGE_KEY);
+    const normalizedContent = storedContent?.trim() ?? "";
+    return normalizedContent || null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
This PR adds an Add As Recipe action in Experiment that saves the latest assistant output to sessionStorage and routes to /recipes/new. It introduces a shared draft utility for saving and consuming the transfer payload. The New Recipe page now consumes that draft on load, switches to Paste Text mode, and clears transfer state after hydration. It also adds tests that cover the storage handoff and hydration behavior across both pages.