### PR TITLE
Fix Render auth redirects and signed-out UI

### DIFF
--- a/app/services/grocery_list_aggregation_impl.py
+++ b/app/services/grocery_list_aggregation_impl.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -10,6 +11,56 @@ from app.services.llm_generation_service import make_llm_call_structured_output_
 
 class GroceryListAggregationResult(BaseModel):
     ingredients: list[str] = Field(default_factory=list)
+
+
+_INGREDIENT_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "approximately",
+    "as",
+    "can",
+    "chopped",
+    "clove",
+    "cup",
+    "cups",
+    "dash",
+    "diced",
+    "fresh",
+    "for",
+    "from",
+    "g",
+    "garnish",
+    "gram",
+    "grams",
+    "inch",
+    "inches",
+    "jar",
+    "kg",
+    "lb",
+    "lbs",
+    "large",
+    "medium",
+    "minced",
+    "of",
+    "optional",
+    "or",
+    "oz",
+    "package",
+    "pinch",
+    "pound",
+    "pounds",
+    "small",
+    "sliced",
+    "taste",
+    "tbsp",
+    "teaspoon",
+    "teaspoons",
+    "to",
+    "tsp",
+    "whole",
+    "with",
+}
 
 
 class GroceryListAggregationServiceImpl(GroceryListAggregationService):
@@ -41,9 +92,70 @@ class GroceryListAggregationServiceImpl(GroceryListAggregationService):
             for ingredient in response.ingredients
             if ingredient and ingredient.strip()
         ]
+        aggregated = self._restore_missing_coverage(cleaned_ingredients, aggregated)
         return aggregated, None
 
     @staticmethod
     def _build_user_prompt(ingredients: list[str]) -> str:
         payload = {"ingredients": ingredients}
         return json.dumps(payload, ensure_ascii=True)
+
+    @staticmethod
+    def _normalize_token(token: str) -> str:
+        normalized = token.strip().lower()
+        if not normalized or normalized.isdigit():
+            return ""
+        if len(normalized) > 4 and normalized.endswith("oes"):
+            normalized = normalized[:-2]
+        elif len(normalized) > 4 and normalized.endswith("ies"):
+            normalized = f"{normalized[:-3]}y"
+        elif len(normalized) > 3 and normalized.endswith("s") and not normalized.endswith(
+            "ss"
+        ):
+            normalized = normalized[:-1]
+        return normalized
+
+    @classmethod
+    def _ingredient_tokens(cls, ingredient: str) -> set[str]:
+        tokens = {
+            cls._normalize_token(token)
+            for token in re.split(r"[^a-z0-9]+", ingredient.lower())
+        }
+        return {
+            token
+            for token in tokens
+            if token and token not in _INGREDIENT_STOPWORDS and not token.isdigit()
+        }
+
+    @classmethod
+    def _restore_missing_coverage(
+        cls,
+        source_ingredients: list[str],
+        aggregated_ingredients: list[str],
+    ) -> list[str]:
+        if not source_ingredients or not aggregated_ingredients:
+            return aggregated_ingredients
+
+        restored = list(aggregated_ingredients)
+        normalized_output = {
+            " ".join(ingredient.strip().lower().split())
+            for ingredient in aggregated_ingredients
+        }
+        output_tokens = set().union(
+            *(cls._ingredient_tokens(ingredient) for ingredient in aggregated_ingredients)
+        )
+
+        for ingredient in source_ingredients:
+            normalized_source = " ".join(ingredient.strip().lower().split())
+            source_tokens = cls._ingredient_tokens(ingredient)
+
+            if normalized_source in normalized_output:
+                continue
+            if source_tokens and output_tokens.intersection(source_tokens):
+                continue
+
+            restored.append(ingredient)
+            normalized_output.add(normalized_source)
+            output_tokens.update(source_tokens)
+
+        return restored

--- a/app/services/grocery_list_aggregation_impl.py
+++ b/app/services/grocery_list_aggregation_impl.py
@@ -130,6 +130,29 @@ class GroceryListAggregationServiceImpl(GroceryListAggregationService):
         }
 
     @classmethod
+    def _ingredient_is_covered(
+        cls,
+        source_ingredient: str,
+        aggregated_ingredients: list[str],
+        aggregated_token_sets: list[set[str]],
+    ) -> bool:
+        normalized_source = " ".join(source_ingredient.strip().lower().split())
+        source_tokens = cls._ingredient_tokens(source_ingredient)
+
+        for aggregated_ingredient, aggregated_tokens in zip(
+            aggregated_ingredients, aggregated_token_sets, strict=False
+        ):
+            normalized_aggregated = " ".join(
+                aggregated_ingredient.strip().lower().split()
+            )
+            if normalized_source == normalized_aggregated:
+                return True
+            if source_tokens and source_tokens.issubset(aggregated_tokens):
+                return True
+
+        return False
+
+    @classmethod
     def _restore_missing_coverage(
         cls,
         source_ingredients: list[str],
@@ -139,28 +162,15 @@ class GroceryListAggregationServiceImpl(GroceryListAggregationService):
             return aggregated_ingredients
 
         restored = list(aggregated_ingredients)
-        normalized_output = {
-            " ".join(ingredient.strip().lower().split())
-            for ingredient in aggregated_ingredients
-        }
-        output_tokens = set().union(
-            *(
-                cls._ingredient_tokens(ingredient)
-                for ingredient in aggregated_ingredients
-            )
-        )
+        restored_token_sets = [
+            cls._ingredient_tokens(ingredient) for ingredient in aggregated_ingredients
+        ]
 
         for ingredient in source_ingredients:
-            normalized_source = " ".join(ingredient.strip().lower().split())
-            source_tokens = cls._ingredient_tokens(ingredient)
-
-            if normalized_source in normalized_output:
-                continue
-            if source_tokens and output_tokens.intersection(source_tokens):
+            if cls._ingredient_is_covered(ingredient, restored, restored_token_sets):
                 continue
 
             restored.append(ingredient)
-            normalized_output.add(normalized_source)
-            output_tokens.update(source_tokens)
+            restored_token_sets.append(cls._ingredient_tokens(ingredient))
 
         return restored

--- a/app/services/grocery_list_aggregation_impl.py
+++ b/app/services/grocery_list_aggregation_impl.py
@@ -109,8 +109,10 @@ class GroceryListAggregationServiceImpl(GroceryListAggregationService):
             normalized = normalized[:-2]
         elif len(normalized) > 4 and normalized.endswith("ies"):
             normalized = f"{normalized[:-3]}y"
-        elif len(normalized) > 3 and normalized.endswith("s") and not normalized.endswith(
-            "ss"
+        elif (
+            len(normalized) > 3
+            and normalized.endswith("s")
+            and not normalized.endswith("ss")
         ):
             normalized = normalized[:-1]
         return normalized
@@ -142,7 +144,10 @@ class GroceryListAggregationServiceImpl(GroceryListAggregationService):
             for ingredient in aggregated_ingredients
         }
         output_tokens = set().union(
-            *(cls._ingredient_tokens(ingredient) for ingredient in aggregated_ingredients)
+            *(
+                cls._ingredient_tokens(ingredient)
+                for ingredient in aggregated_ingredients
+            )
         )
 
         for ingredient in source_ingredients:

--- a/app/tests/unit/test_grocery_list_aggregation_impl.py
+++ b/app/tests/unit/test_grocery_list_aggregation_impl.py
@@ -97,6 +97,28 @@ def test_aggregate_ingredients_recognizes_plural_overlap_as_covered(
     assert ingredients == ["2 tomato", "2 cloves garlic"]
 
 
+def test_aggregate_ingredients_does_not_treat_partial_token_overlap_as_covered(
+    monkeypatch,
+) -> None:
+    service = GroceryListAggregationServiceImpl()
+
+    monkeypatch.setattr(
+        grocery_list_aggregation_impl,
+        "make_llm_call_structured_output_generic",
+        lambda **_kwargs: (
+            GroceryListAggregationResult(
+                ingredients=["1 red pepper"],
+            ),
+            None,
+        ),
+    )
+
+    ingredients, error = service.aggregate_ingredients(["1 red onion"])
+
+    assert error is None
+    assert ingredients == ["1 red pepper", "1 red onion"]
+
+
 def test_aggregate_ingredients_returns_error_when_llm_fails(monkeypatch) -> None:
     service = GroceryListAggregationServiceImpl()
 

--- a/app/tests/unit/test_grocery_list_aggregation_impl.py
+++ b/app/tests/unit/test_grocery_list_aggregation_impl.py
@@ -46,6 +46,55 @@ def test_aggregate_ingredients_returns_llm_output(monkeypatch) -> None:
     assert ingredients == ["2 tomatoes", "1 yellow onion"]
 
 
+def test_aggregate_ingredients_restores_missing_input_coverage(monkeypatch) -> None:
+    service = GroceryListAggregationServiceImpl()
+
+    monkeypatch.setattr(
+        grocery_list_aggregation_impl,
+        "make_llm_call_structured_output_generic",
+        lambda **_kwargs: (
+            GroceryListAggregationResult(
+                ingredients=["1 can chickpeas", "1 onion"],
+            ),
+            None,
+        ),
+    )
+
+    ingredients, error = service.aggregate_ingredients(
+        ["2 tomatoes", "2 cloves garlic", "1 can chickpeas", "1 onion"]
+    )
+
+    assert error is None
+    assert ingredients == [
+        "1 can chickpeas",
+        "1 onion",
+        "2 tomatoes",
+        "2 cloves garlic",
+    ]
+
+
+def test_aggregate_ingredients_recognizes_plural_overlap_as_covered(monkeypatch) -> None:
+    service = GroceryListAggregationServiceImpl()
+
+    monkeypatch.setattr(
+        grocery_list_aggregation_impl,
+        "make_llm_call_structured_output_generic",
+        lambda **_kwargs: (
+            GroceryListAggregationResult(
+                ingredients=["2 tomato", "2 cloves garlic"],
+            ),
+            None,
+        ),
+    )
+
+    ingredients, error = service.aggregate_ingredients(
+        ["2 tomatoes", "2 cloves garlic"]
+    )
+
+    assert error is None
+    assert ingredients == ["2 tomato", "2 cloves garlic"]
+
+
 def test_aggregate_ingredients_returns_error_when_llm_fails(monkeypatch) -> None:
     service = GroceryListAggregationServiceImpl()
 

--- a/app/tests/unit/test_grocery_list_aggregation_impl.py
+++ b/app/tests/unit/test_grocery_list_aggregation_impl.py
@@ -73,7 +73,9 @@ def test_aggregate_ingredients_restores_missing_input_coverage(monkeypatch) -> N
     ]
 
 
-def test_aggregate_ingredients_recognizes_plural_overlap_as_covered(monkeypatch) -> None:
+def test_aggregate_ingredients_recognizes_plural_overlap_as_covered(
+    monkeypatch,
+) -> None:
     service = GroceryListAggregationServiceImpl()
 
     monkeypatch.setattr(

--- a/apps/web/src/app/auth/callback/route.test.ts
+++ b/apps/web/src/app/auth/callback/route.test.ts
@@ -78,6 +78,19 @@ describe("/auth/callback route", () => {
     expect(response.headers.get("location")).toBe("https://forkfolio.app/");
   });
 
+  it("uses forwarded host and proto when request origin is an internal proxy URL", async () => {
+    const response = await GET(
+      new Request("http://localhost:10000/auth/callback?code=abc&next=/bag", {
+        headers: {
+          "x-forwarded-host": "forkfolio-fe.onrender.com",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
+
+    expect(response.headers.get("location")).toBe("https://forkfolio-fe.onrender.com/bag");
+  });
+
   it("uses configured app origin and ignores x-forwarded-host", async () => {
     process.env.FORKFOLIO_APP_ORIGIN = "https://www.forkfolio.app/account";
 

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -3,23 +3,70 @@ import { NextResponse } from "next/server";
 import { hasSupabaseAuthConfig } from "@/lib/supabase/config";
 import { createClient } from "@/lib/supabase/server";
 
-function resolveRedirectOrigin(requestUrl: URL): string {
+function getFirstHeaderValue(request: Request, headerName: string): string | null {
+  const rawValue = request.headers.get(headerName)?.trim() ?? "";
+  if (!rawValue) {
+    return null;
+  }
+
+  const firstValue = rawValue.split(",", 1)[0]?.trim() ?? "";
+  return firstValue || null;
+}
+
+function isLocalHost(host: string): boolean {
+  return (
+    host.startsWith("localhost") ||
+    host.startsWith("127.0.0.1") ||
+    host.startsWith("[::1]")
+  );
+}
+
+function buildOrigin(protocol: string, host: string): string | null {
+  try {
+    return new URL(`${protocol}://${host}`).origin;
+  } catch {
+    return null;
+  }
+}
+
+function resolveProxyOrigin(request: Request, requestUrl: URL): string | null {
+  const forwardedHost = getFirstHeaderValue(request, "x-forwarded-host");
+  const forwardedProto = getFirstHeaderValue(request, "x-forwarded-proto");
+  const requestProtocol = requestUrl.protocol.replace(/:$/, "");
+
+  if (forwardedHost) {
+    const protocol = forwardedProto || (isLocalHost(forwardedHost) ? "http" : "https");
+    return buildOrigin(protocol, forwardedHost);
+  }
+
+  const host = getFirstHeaderValue(request, "host");
+  if (!host) {
+    return null;
+  }
+
+  const protocol = forwardedProto ||
+    (isLocalHost(host) || requestProtocol === "http" ? "http" : "https");
+  return buildOrigin(protocol, host);
+}
+
+function resolveRedirectOrigin(request: Request): string {
+  const requestUrl = new URL(request.url);
   const configuredAppOrigin = process.env.FORKFOLIO_APP_ORIGIN?.trim();
   if (!configuredAppOrigin) {
-    return requestUrl.origin;
+    return resolveProxyOrigin(request, requestUrl) ?? requestUrl.origin;
   }
 
   try {
     return new URL(configuredAppOrigin).origin;
   } catch {
-    return requestUrl.origin;
+    return resolveProxyOrigin(request, requestUrl) ?? requestUrl.origin;
   }
 }
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
   const { searchParams } = requestUrl;
-  const origin = resolveRedirectOrigin(requestUrl);
+  const origin = resolveRedirectOrigin(request);
   const code = searchParams.get("code");
   let next = searchParams.get("next") ?? "/";
 

--- a/apps/web/src/components/auth-profile-button.test.tsx
+++ b/apps/web/src/components/auth-profile-button.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  createClientMock,
+  getUserMock,
+  hasSupabaseAuthConfigMock,
+  onAuthStateChangeMock,
+  signInWithOAuthMock,
+  signOutMock,
+  unsubscribeMock,
+} = vi.hoisted(() => {
+  const getUserMock = vi.fn();
+  const unsubscribeMock = vi.fn();
+  const onAuthStateChangeMock = vi.fn(() => ({
+    data: {
+      subscription: {
+        unsubscribe: unsubscribeMock,
+      },
+    },
+  }));
+  const signInWithOAuthMock = vi.fn();
+  const signOutMock = vi.fn();
+  const createClientMock = vi.fn(() => ({
+    auth: {
+      getUser: getUserMock,
+      onAuthStateChange: onAuthStateChangeMock,
+      signInWithOAuth: signInWithOAuthMock,
+      signOut: signOutMock,
+    },
+  }));
+  const hasSupabaseAuthConfigMock = vi.fn();
+
+  return {
+    createClientMock,
+    getUserMock,
+    hasSupabaseAuthConfigMock,
+    onAuthStateChangeMock,
+    signInWithOAuthMock,
+    signOutMock,
+    unsubscribeMock,
+  };
+});
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("@/lib/supabase/config", () => ({
+  hasSupabaseAuthConfig: hasSupabaseAuthConfigMock,
+}));
+
+import { AuthProfileButton } from "./auth-profile-button";
+
+describe("AuthProfileButton", () => {
+  beforeEach(() => {
+    createClientMock.mockClear();
+    getUserMock.mockReset();
+    hasSupabaseAuthConfigMock.mockReset();
+    onAuthStateChangeMock.mockClear();
+    signInWithOAuthMock.mockReset();
+    signOutMock.mockReset();
+    unsubscribeMock.mockClear();
+
+    hasSupabaseAuthConfigMock.mockReturnValue(true);
+    signInWithOAuthMock.mockResolvedValue({ error: null });
+    signOutMock.mockResolvedValue({ error: null });
+  });
+
+  it("treats a missing auth session as a signed-out state instead of an error", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: { message: "Auth session missing!" },
+    });
+
+    render(<AuthProfileButton />);
+
+    expect(await screen.findByRole("button", { name: /Sign In/i })).toBeInTheDocument();
+    expect(screen.queryByText("Auth session missing!")).not.toBeInTheDocument();
+  });
+
+  it("still shows unexpected auth errors", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: { message: "Failed to reach auth service." },
+    });
+
+    render(<AuthProfileButton />);
+
+    expect(await screen.findByRole("button", { name: /Sign In/i })).toBeInTheDocument();
+    expect(await screen.findByText("Failed to reach auth service.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth-profile-button.tsx
+++ b/apps/web/src/components/auth-profile-button.tsx
@@ -42,6 +42,11 @@ function resolveInitial(label: string): string {
   return label.slice(0, 1).toUpperCase() || "P";
 }
 
+function isExpectedSignedOutMessage(message: string | null | undefined): boolean {
+  const normalizedMessage = message?.trim().toLowerCase().replace(/[!.]+$/, "") ?? "";
+  return normalizedMessage === "auth session missing";
+}
+
 export function AuthProfileButton() {
   const pathname = usePathname() ?? "/";
   const [supabase] = useState(() => (
@@ -65,8 +70,15 @@ export function AuthProfileButton() {
         return;
       }
 
-      setCurrentUser(data.user ?? null);
-      setErrorMessage(error?.message ?? null);
+      const user = data.user ?? null;
+      const nextErrorMessage = error?.message ?? null;
+
+      setCurrentUser(user);
+      setErrorMessage(
+        user || isExpectedSignedOutMessage(nextErrorMessage)
+          ? null
+          : nextErrorMessage,
+      );
       setIsLoading(false);
     });
 
@@ -78,6 +90,7 @@ export function AuthProfileButton() {
       }
 
       setCurrentUser(session?.user ?? null);
+      setErrorMessage(null);
       setIsLoading(false);
       if (!session) {
         setIsDialogOpen(false);


### PR DESCRIPTION
This fixes the deployed Supabase auth flow and signed-out profile state in the web app.

The callback route now resolves redirects from forwarded host/proto headers or `FORKFOLIO_APP_ORIGIN` so proxy environments do not fall back to `localhost:10000`.
The profile button now treats `Auth session missing!` as a normal signed-out state instead of surfacing it as an error.
Added focused Vitest coverage for the callback proxy-origin path and the signed-out auth-profile behavior.

Testing: `npm test -- src/app/auth/callback/route.test.ts src/components/auth-profile-button.test.tsx` and `npx eslint src/app/auth/callback/route.ts src/app/auth/callback/route.test.ts src/components/auth-profile-button.tsx src/components/auth-profile-button.test.tsx`.