### PR TITLE
Add recipe visibility and creator ownership

### DIFF
--- a/app/api/schemas/ingest.py
+++ b/app/api/schemas/ingest.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field
 
 
@@ -36,6 +38,16 @@ class RecipeIngestionRequest(BaseModel):
         False,
         description="Mark the resulting recipe as test data.",
         alias="isTest",
+    )
+    is_public: bool = Field(
+        True,
+        description="Whether the saved recipe is public or private.",
+        alias="isPublic",
+    )
+    created_by_user_id: UUID | None = Field(
+        None,
+        description="User id that created the recipe.",
+        alias="createdByUserId",
     )
 
 

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from uuid import UUID
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 
 from app.api.schemas import (
     GroceryListCreateRequest,
@@ -41,12 +43,14 @@ def _semantic_search_cache_key(
     limit: int,
     include_test_data: bool,
     rerank_enabled: bool,
+    viewer_user_id: str | None,
 ) -> str:
     return hash_cache_key(
         "semantic_search",
         normalized_query,
         str(limit),
         str(include_test_data),
+        viewer_user_id or "public-only",
         str(settings.SEMANTIC_SEARCH_MAX_DISTANCE),
         str(rerank_enabled),
         str(settings.SEMANTIC_SEARCH_RERANK_CANDIDATE_COUNT),
@@ -56,6 +60,16 @@ def _semantic_search_cache_key(
         str(settings.SEMANTIC_SEARCH_RERANK_CUISINE_BOOST),
         str(settings.SEMANTIC_SEARCH_RERANK_FAMILY_BOOST),
     )
+
+
+def _viewer_user_id_from_request(request: Request) -> str | None:
+    raw_value = request.headers.get("x-viewer-user-id", "").strip()
+    if not raw_value:
+        return None
+    try:
+        return str(UUID(raw_value))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid X-Viewer-User-Id header") from exc
 
 
 @router.post("/process-and-store")
@@ -105,6 +119,7 @@ def process_and_store_recipe(
         recipe_data = recipe_manager.get_full_recipe(
             recipe_id,
             include_test_data=ingestion_request.is_test,
+            viewer_user_id=created_by_user_id,
         )
         if not recipe_data:
             logger.error(f"Duplicate recipe found but not retrieved: {recipe_id}")
@@ -124,6 +139,7 @@ def process_and_store_recipe(
     recipe_data = recipe_manager.get_full_recipe(
         recipe_id,
         include_test_data=ingestion_request.is_test,
+        viewer_user_id=created_by_user_id,
     )
     if not recipe_data:
         logger.error(f"Recipe stored but not found: {recipe_id}")
@@ -187,6 +203,7 @@ def preview_recipe_from_url(
 
 @router.get("/")
 def list_recipes(
+    request: Request,
     limit: int = Query(
         default=50,
         ge=1,
@@ -210,6 +227,7 @@ def list_recipes(
     """
     cursor_created_at = None
     cursor_id = None
+    viewer_user_id = _viewer_user_id_from_request(request)
 
     if cursor:
         try:
@@ -223,6 +241,7 @@ def list_recipes(
             cursor_created_at=cursor_created_at,
             cursor_id=cursor_id,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         has_more = len(page_with_sentinel) > limit
         recipes_page = page_with_sentinel[:limit]
@@ -253,6 +272,7 @@ def list_recipes(
 
 @router.get("/search/semantic")
 def semantic_search_recipes(
+    request: Request,
     query: str = Query(
         ...,
         min_length=2,
@@ -294,11 +314,13 @@ def semantic_search_recipes(
     rerank_enabled = (
         settings.SEMANTIC_SEARCH_RERANK_ENABLED if rerank is None else rerank
     )
+    viewer_user_id = _viewer_user_id_from_request(request)
     cache_key = _semantic_search_cache_key(
         normalized_query=normalized_query,
         limit=limit,
         include_test_data=include_test_data,
         rerank_enabled=rerank_enabled,
+        viewer_user_id=viewer_user_id,
     )
     cached_response = semantic_search_cache.get(cache_key)
     if cached_response is not None:
@@ -330,6 +352,7 @@ def semantic_search_recipes(
             limit=candidate_limit,
             max_distance=settings.SEMANTIC_SEARCH_MAX_DISTANCE,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         if rerank_enabled and len(matches) > 1:
             ranked_items = []
@@ -338,6 +361,7 @@ def semantic_search_recipes(
                     matches,
                     recipe_manager,
                     include_test_data=include_test_data,
+                    viewer_user_id=viewer_user_id,
                 )
                 ranked_items = reranker_service.rerank(
                     query=normalized_query,
@@ -382,6 +406,7 @@ def semantic_search_recipes(
 
 @router.get("/search/by-name")
 def search_recipes_by_name(
+    request: Request,
     query: str = Query(
         ...,
         min_length=3,
@@ -400,6 +425,7 @@ def search_recipes_by_name(
     recipe_manager=recipe_manager_dep,
 ) -> dict:
     normalized_query = normalize_search_query(query)
+    viewer_user_id = _viewer_user_id_from_request(request)
     if len(normalized_query) < 3:
         raise HTTPException(
             status_code=422,
@@ -411,6 +437,7 @@ def search_recipes_by_name(
             title_query=normalized_query,
             limit=limit,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         results = [
             {
@@ -436,6 +463,7 @@ def search_recipes_by_name(
 
 @router.post("/grocery-list")
 def create_grocery_list(
+    request: Request,
     grocery_list_request: GroceryListCreateRequest = GROCERY_LIST_BODY,
     include_test_data: bool = Query(
         default=False,
@@ -450,10 +478,12 @@ def create_grocery_list(
     recipe_ids = list(
         dict.fromkeys(str(recipe_id) for recipe_id in grocery_list_request.recipe_ids)
     )
+    viewer_user_id = _viewer_user_id_from_request(request)
     try:
         ingredients_by_recipe = recipe_manager.get_ingredients_for_recipes(
             recipe_ids,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         missing_recipe_ids = [
             recipe_id
@@ -500,6 +530,7 @@ def create_grocery_list(
 
 @router.get("/{recipe_id}")
 def get_recipe(
+    request: Request,
     recipe_id: str,
     include_test_data: bool = Query(
         default=False,
@@ -514,11 +545,13 @@ def get_recipe(
     or 404 if the recipe is not found.
     """
     logger.info(f"Retrieving recipe with ID: {recipe_id}")
+    viewer_user_id = _viewer_user_id_from_request(request)
 
     try:
         recipe_data = recipe_manager.get_full_recipe(
             recipe_id,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
 
         if not recipe_data:
@@ -539,6 +572,7 @@ def get_recipe(
 
 @router.get("/{recipe_id}/all")
 def get_recipe_all(
+    request: Request,
     recipe_id: str,
     include_test_data: bool = Query(
         default=False,
@@ -553,11 +587,13 @@ def get_recipe_all(
     or 404 if the recipe is not found.
     """
     logger.info(f"Retrieving full recipe with embeddings for ID: {recipe_id}")
+    viewer_user_id = _viewer_user_id_from_request(request)
 
     try:
         recipe_data = recipe_manager.get_full_recipe_with_embeddings(
             recipe_id,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
 
         if not recipe_data:

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -69,7 +69,9 @@ def _viewer_user_id_from_request(request: Request) -> str | None:
     try:
         return str(UUID(raw_value))
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail="Invalid X-Viewer-User-Id header") from exc
+        raise HTTPException(
+            status_code=400, detail="Invalid X-Viewer-User-Id header"
+        ) from exc
 
 
 @router.post("/process-and-store")

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -78,11 +78,18 @@ def process_and_store_recipe(
     source_url = (
         str(ingestion_request.source_url) if ingestion_request.source_url else None
     )
+    created_by_user_id = (
+        str(ingestion_request.created_by_user_id)
+        if ingestion_request.created_by_user_id
+        else None
+    )
     recipe_id, error, created = processing_service.process_raw_recipe(
         raw_input=ingestion_request.raw_input,
         source_url=source_url,
         enforce_deduplication=ingestion_request.enforce_deduplication,
         is_test=ingestion_request.is_test,
+        is_public=ingestion_request.is_public,
+        created_by_user_id=created_by_user_id,
     )
 
     if error:

--- a/app/api/v1/helpers/recipe_search.py
+++ b/app/api/v1/helpers/recipe_search.py
@@ -271,6 +271,7 @@ def build_rerank_candidates(
     matches: list[dict],
     recipe_manager,
     include_test_data: bool = False,
+    viewer_user_id: str | None = None,
 ) -> list[dict]:
     recipe_ids = []
     for item in matches:
@@ -285,6 +286,7 @@ def build_rerank_candidates(
                 recipe_ids=recipe_ids,
                 max_ingredients=8,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
         except Exception as exc:
             logger.warning(

--- a/app/services/data/managers/recipe_manager.py
+++ b/app/services/data/managers/recipe_manager.py
@@ -24,6 +24,7 @@ LEFT JOIN LATERAL (
 ) s ON true
 WHERE r.id = %s
   AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
 """
 EMBEDDINGS_SELECT_SQL = """
 SELECT id, embedding_type, embedding, created_at
@@ -40,6 +41,7 @@ FROM recipe_embeddings e
 JOIN recipes r ON r.id = e.recipe_id
 WHERE e.embedding_type = %s
   AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
   AND e.embedding <=> %s::vector <= %s
 ORDER BY distance
 LIMIT %s
@@ -50,6 +52,7 @@ FROM recipe_ingredients ri
 JOIN recipes r ON r.id = ri.recipe_id
 WHERE ri.recipe_id = ANY(%s::uuid[])
   AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
 ORDER BY ri.recipe_id, ri.order_index
 """
 ALL_INGREDIENTS_FOR_RECIPES_SQL = """
@@ -64,51 +67,55 @@ FROM recipes r
 LEFT JOIN recipe_ingredients i ON i.recipe_id = r.id
 WHERE r.id = ANY(%s::uuid[])
   AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
 GROUP BY r.id
 """
 RECIPES_PAGE_SQL = """
 SELECT
-    id,
-    title,
-    servings,
-    total_time,
-    source_url,
-    is_public,
-    created_by_user_id,
-    is_test_data,
-    created_at,
-    updated_at
-FROM recipes
-WHERE (%s OR COALESCE(is_test_data, FALSE) = FALSE)
-ORDER BY created_at DESC, id DESC
+    r.id,
+    r.title,
+    r.servings,
+    r.total_time,
+    r.source_url,
+    r.is_public,
+    r.created_by_user_id,
+    r.is_test_data,
+    r.created_at,
+    r.updated_at
+FROM recipes r
+WHERE (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
+ORDER BY r.created_at DESC, r.id DESC
 LIMIT %s
 """
 RECIPES_PAGE_WITH_CURSOR_SQL = """
 SELECT
-    id,
-    title,
-    servings,
-    total_time,
-    source_url,
-    is_public,
-    created_by_user_id,
-    is_test_data,
-    created_at,
-    updated_at
-FROM recipes
-WHERE (created_at, id) < (%s::timestamp, %s::uuid)
-  AND (%s OR COALESCE(is_test_data, FALSE) = FALSE)
-ORDER BY created_at DESC, id DESC
+    r.id,
+    r.title,
+    r.servings,
+    r.total_time,
+    r.source_url,
+    r.is_public,
+    r.created_by_user_id,
+    r.is_test_data,
+    r.created_at,
+    r.updated_at
+FROM recipes r
+WHERE (r.created_at, r.id) < (%s::timestamp, %s::uuid)
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
+ORDER BY r.created_at DESC, r.id DESC
 LIMIT %s
 """
 RECIPES_BY_TITLE_SQL = """
-SELECT id, title, created_at
-FROM recipes
-WHERE title ILIKE %s
-  AND (%s OR COALESCE(is_test_data, FALSE) = FALSE)
+SELECT r.id, r.title, r.created_at
+FROM recipes r
+WHERE r.title ILIKE %s
+  AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
 ORDER BY
-    CASE WHEN lower(title) = lower(%s) THEN 0 ELSE 1 END,
-    created_at DESC
+    CASE WHEN lower(r.title) = lower(%s) THEN 0 ELSE 1 END,
+    r.created_at DESC
 LIMIT %s
 """
 
@@ -219,8 +226,12 @@ class RecipeManager(BaseManager):
         cursor,
         recipe_id: str,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> Optional[dict]:
-        cursor.execute(RECIPE_WITH_CHILDREN_SQL, (recipe_id, include_test_data))
+        cursor.execute(
+            RECIPE_WITH_CHILDREN_SQL,
+            (recipe_id, include_test_data, viewer_user_id),
+        )
         row = cursor.fetchone()
         if not row:
             return None
@@ -300,7 +311,10 @@ class RecipeManager(BaseManager):
             raise DatabaseError(f"Failed to create recipe: {e!s}") from e
 
     def get_full_recipe(
-        self, recipe_id: str, include_test_data: bool = False
+        self,
+        recipe_id: str,
+        include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> Optional[dict]:
         """Get a complete recipe with ingredients and instructions"""
         try:
@@ -309,6 +323,7 @@ class RecipeManager(BaseManager):
                     cursor=cursor,
                     recipe_id=recipe_id,
                     include_test_data=include_test_data,
+                    viewer_user_id=viewer_user_id,
                 )
                 if not recipe_data:
                     return None
@@ -318,7 +333,10 @@ class RecipeManager(BaseManager):
             raise DatabaseError(f"Failed to get recipe: {e!s}") from e
 
     def get_full_recipe_with_embeddings(
-        self, recipe_id: str, include_test_data: bool = False
+        self,
+        recipe_id: str,
+        include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> Optional[dict]:
         """Get a complete recipe with ingredients, instructions, and embeddings."""
         try:
@@ -327,6 +345,7 @@ class RecipeManager(BaseManager):
                     cursor=cursor,
                     recipe_id=recipe_id,
                     include_test_data=include_test_data,
+                    viewer_user_id=viewer_user_id,
                 )
                 if not recipe_data:
                     return None
@@ -343,6 +362,7 @@ class RecipeManager(BaseManager):
         cursor_created_at: datetime | None = None,
         cursor_id: str | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         """List recipes ordered by newest first with optional cursor pagination."""
         query_limit = max(1, int(limit))
@@ -351,10 +371,19 @@ class RecipeManager(BaseManager):
                 if cursor_created_at is not None and cursor_id is not None:
                     cursor.execute(
                         RECIPES_PAGE_WITH_CURSOR_SQL,
-                        (cursor_created_at, cursor_id, include_test_data, query_limit),
+                        (
+                            cursor_created_at,
+                            cursor_id,
+                            include_test_data,
+                            viewer_user_id,
+                            query_limit,
+                        ),
                     )
                 else:
-                    cursor.execute(RECIPES_PAGE_SQL, (include_test_data, query_limit))
+                    cursor.execute(
+                        RECIPES_PAGE_SQL,
+                        (include_test_data, viewer_user_id, query_limit),
+                    )
                 return [dict(row) for row in cursor.fetchall()]
         except Exception as e:
             raise DatabaseError(f"Failed to list recipes: {e!s}") from e
@@ -364,6 +393,7 @@ class RecipeManager(BaseManager):
         recipe_ids: list[str],
         max_ingredients: int = 8,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict[str, list[str]]:
         """
         Fetch ingredient previews for many recipes in one query.
@@ -390,7 +420,7 @@ class RecipeManager(BaseManager):
             with self.get_db_context() as (_conn, cursor):
                 cursor.execute(
                     INGREDIENTS_FOR_RECIPES_SQL,
-                    (normalized_ids, include_test_data),
+                    (normalized_ids, include_test_data, viewer_user_id),
                 )
                 for row in cursor.fetchall():
                     recipe_id = str(row["recipe_id"])
@@ -407,6 +437,7 @@ class RecipeManager(BaseManager):
         title_query: str,
         limit: int = 5,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         normalized_query = (title_query or "").strip()
         if not normalized_query:
@@ -421,6 +452,7 @@ class RecipeManager(BaseManager):
                     (
                         like_pattern,
                         include_test_data,
+                        viewer_user_id,
                         normalized_query,
                         query_limit,
                     ),
@@ -441,6 +473,7 @@ class RecipeManager(BaseManager):
         self,
         recipe_ids: list[str],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict[str, list[str]]:
         """
         Fetch full ingredient lists for many recipes in one query.
@@ -466,7 +499,7 @@ class RecipeManager(BaseManager):
             with self.get_db_context() as (_conn, cursor):
                 cursor.execute(
                     ALL_INGREDIENTS_FOR_RECIPES_SQL,
-                    (normalized_ids, include_test_data),
+                    (normalized_ids, include_test_data, viewer_user_id),
                 )
                 rows = cursor.fetchall()
                 ingredients_by_recipe: dict[str, list[str]] = {}
@@ -486,6 +519,7 @@ class RecipeManager(BaseManager):
         limit: int = 10,
         max_distance: float = 0.35,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         """Find recipes with embeddings closest to the provided embedding."""
         try:
@@ -496,6 +530,7 @@ class RecipeManager(BaseManager):
                         embedding,
                         embedding_type,
                         include_test_data,
+                        viewer_user_id,
                         embedding,
                         max_distance,
                         limit,
@@ -511,6 +546,7 @@ class RecipeManager(BaseManager):
         embedding: list[float],
         embedding_type: str,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> Optional[dict]:
         """Find the nearest embedding by cosine distance."""
         try:
@@ -524,10 +560,14 @@ class RecipeManager(BaseManager):
                 JOIN recipes r ON r.id = e.recipe_id
                 WHERE e.embedding_type = %s
                   AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
+                  AND (COALESCE(r.is_public, TRUE) = TRUE OR r.created_by_user_id = %s::uuid)
                 ORDER BY distance
                 LIMIT 1
                 """
-                cursor.execute(sql, (embedding, embedding_type, include_test_data))
+                cursor.execute(
+                    sql,
+                    (embedding, embedding_type, include_test_data, viewer_user_id),
+                )
                 row = cursor.fetchone()
                 return dict(row) if row else None
         except Exception as e:

--- a/app/services/data/managers/recipe_manager.py
+++ b/app/services/data/managers/recipe_manager.py
@@ -73,6 +73,8 @@ SELECT
     servings,
     total_time,
     source_url,
+    is_public,
+    created_by_user_id,
     is_test_data,
     created_at,
     updated_at
@@ -88,6 +90,8 @@ SELECT
     servings,
     total_time,
     source_url,
+    is_public,
+    created_by_user_id,
     is_test_data,
     created_at,
     updated_at
@@ -134,24 +138,34 @@ class RecipeManager(BaseManager):
         total_time: Optional[str],
         is_test_data: bool = False,
         source_url: Optional[str] = None,
+        is_public: bool = True,
+        created_by_user_id: str | None = None,
     ) -> None:
-        if source_url is None:
-            sql = """
-            INSERT INTO recipes (id, title, servings, total_time, is_test_data)
-            VALUES (%s, %s, %s, %s, %s)
-            """
-            cursor.execute(sql, (recipe_id, title, servings, total_time, is_test_data))
-            return
-
         sql = """
         INSERT INTO recipes (
-            id, title, servings, total_time, source_url, is_test_data
+            id,
+            title,
+            servings,
+            total_time,
+            source_url,
+            is_public,
+            created_by_user_id,
+            is_test_data
         )
-        VALUES (%s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         """
         cursor.execute(
             sql,
-            (recipe_id, title, servings, total_time, source_url, is_test_data),
+            (
+                recipe_id,
+                title,
+                servings,
+                total_time,
+                source_url,
+                is_public,
+                created_by_user_id,
+                is_test_data,
+            ),
         )
 
     def _insert_ingredients(
@@ -250,6 +264,8 @@ class RecipeManager(BaseManager):
         embedding_type: Optional[str] = None,
         embedding: Optional[list[float]] = None,
         is_test_data: bool = False,
+        is_public: bool = True,
+        created_by_user_id: str | None = None,
     ) -> str:
         """Create recipe from a model with ingredients, instructions, and embeddings."""
         recipe_id = self._generate_id()
@@ -263,6 +279,8 @@ class RecipeManager(BaseManager):
                     servings=recipe.servings,
                     total_time=recipe.total_time,
                     source_url=source_url,
+                    is_public=is_public,
+                    created_by_user_id=created_by_user_id,
                     is_test_data=is_test_data,
                 )
                 self._insert_ingredients(cursor, recipe_id, recipe.ingredients)

--- a/app/services/grocery_list_aggregation_impl.py
+++ b/app/services/grocery_list_aggregation_impl.py
@@ -41,6 +41,11 @@ class GroceryListAggregationServiceImpl(GroceryListAggregationService):
             for ingredient in response.ingredients
             if ingredient and ingredient.strip()
         ]
+        if not aggregated:
+            # Fall back to the original cleaned list if the LLM returns an empty
+            # aggregation. An empty grocery list is worse UX than preserving the
+            # source ingredients.
+            return cleaned_ingredients, None
         return aggregated, None
 
     @staticmethod

--- a/app/services/recipe_dedupe_impl.py
+++ b/app/services/recipe_dedupe_impl.py
@@ -44,6 +44,7 @@ class RecipeDedupeServiceImpl:
         self,
         recipe: Recipe,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> tuple[bool, Optional[str], Optional[list[float]]]:
         embedding_text = RecipeEmbeddingsServiceImpl._build_title_ingredients_text(
             recipe.title, recipe.ingredients
@@ -53,6 +54,7 @@ class RecipeDedupeServiceImpl:
             embedding=embedding,
             embedding_type=self.embedding_type,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         if not nearest:
             return False, None, embedding
@@ -70,6 +72,7 @@ class RecipeDedupeServiceImpl:
         existing_recipe = self.recipe_manager.get_full_recipe(
             nearest["recipe_id"],
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         if not existing_recipe:
             return False, None, embedding

--- a/app/services/recipe_processing_service.py
+++ b/app/services/recipe_processing_service.py
@@ -199,6 +199,7 @@ class RecipeProcessingService:
                     self.dedupe_service.find_duplicate(
                         recipe,
                         include_test_data=is_test,
+                        viewer_user_id=created_by_user_id,
                     )
                 )
                 if is_duplicate and existing_id:

--- a/app/services/recipe_processing_service.py
+++ b/app/services/recipe_processing_service.py
@@ -162,6 +162,8 @@ class RecipeProcessingService:
         source_url: Optional[str] = None,
         enforce_deduplication: bool = True,
         is_test: bool = False,
+        is_public: bool = True,
+        created_by_user_id: str | None = None,
     ) -> tuple[Optional[str], Optional[str], bool]:
         """
         Process raw recipe input through the complete pipeline.
@@ -171,6 +173,8 @@ class RecipeProcessingService:
             source_url: Optional source URL for reference
             enforce_deduplication: When true, attempt to dedupe before inserting
             is_test: Mark the resulting recipe as test data
+            is_public: Whether the stored recipe is public
+            created_by_user_id: User id that created the recipe
 
         Returns:
             Tuple of (recipe_id, error_message, created).
@@ -208,7 +212,14 @@ class RecipeProcessingService:
                     return None, "Failed to generate recipe embeddings", False
 
             # Step 5: Insert into database (recipe + embeddings)
-            recipe_id = self._store_recipe(recipe, source_url, embedding, is_test)
+            recipe_id = self._store_recipe(
+                recipe=recipe,
+                source_url=source_url,
+                embedding=embedding,
+                is_test=is_test,
+                is_public=is_public,
+                created_by_user_id=created_by_user_id,
+            )
             if not recipe_id:
                 return None, "Failed to store recipe in database", False
             logger.info(f"Successfully processed recipe with ID: {recipe_id}")
@@ -524,6 +535,8 @@ class RecipeProcessingService:
         source_url: Optional[str],
         embedding: list[float],
         is_test: bool,
+        is_public: bool,
+        created_by_user_id: str | None,
     ) -> Optional[str]:
         """
         Step 4: Store the recipe and embeddings in the database.
@@ -544,6 +557,8 @@ class RecipeProcessingService:
                 embedding_type="title_ingredients",
                 embedding=embedding,
                 is_test_data=is_test,
+                is_public=is_public,
+                created_by_user_id=created_by_user_id,
             )
 
             logger.info(f"Recipe stored successfully with ID: {recipe_id}")

--- a/app/tests/unit/test_grocery_list_aggregation_impl.py
+++ b/app/tests/unit/test_grocery_list_aggregation_impl.py
@@ -59,3 +59,22 @@ def test_aggregate_ingredients_returns_error_when_llm_fails(monkeypatch) -> None
 
     assert ingredients is None
     assert error == "llm unavailable"
+
+
+def test_aggregate_ingredients_falls_back_when_llm_returns_empty_list(
+    monkeypatch,
+) -> None:
+    service = GroceryListAggregationServiceImpl()
+
+    monkeypatch.setattr(
+        grocery_list_aggregation_impl,
+        "make_llm_call_structured_output_generic",
+        lambda **_kwargs: (GroceryListAggregationResult(ingredients=[]), None),
+    )
+
+    ingredients, error = service.aggregate_ingredients(
+        [" 1 tomato ", "", "2 cloves garlic"]
+    )
+
+    assert error is None
+    assert ingredients == ["1 tomato", "2 cloves garlic"]

--- a/app/tests/unit/test_grocery_list_endpoint.py
+++ b/app/tests/unit/test_grocery_list_endpoint.py
@@ -23,11 +23,13 @@ class FakeRecipeManager:
         self,
         recipe_ids: list[str],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict[str, list[str]]:
         self.calls.append(
             {
                 "recipe_ids": recipe_ids,
                 "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
             }
         )
         return {
@@ -94,7 +96,11 @@ def test_create_grocery_list_returns_aggregated_ingredients() -> None:
     assert body["ingredients"] == ["2 tomatoes", "2 cloves garlic", "1 onion"]
     assert body["count"] == 3
     assert manager.calls == [
-        {"recipe_ids": [RECIPE_ONE, RECIPE_TWO], "include_test_data": False}
+        {
+            "recipe_ids": [RECIPE_ONE, RECIPE_TWO],
+            "include_test_data": False,
+            "viewer_user_id": None,
+        }
     ]
     assert grocery_service.calls == [
         ["1 tomato", "2 cloves garlic", "1 tomato", "1 onion"]
@@ -120,7 +126,11 @@ def test_create_grocery_list_deduplicates_recipe_ids_before_loading() -> None:
 
     assert response.status_code == 200
     assert manager.calls == [
-        {"recipe_ids": [RECIPE_ONE, RECIPE_TWO], "include_test_data": False}
+        {
+            "recipe_ids": [RECIPE_ONE, RECIPE_TWO],
+            "include_test_data": False,
+            "viewer_user_id": None,
+        }
     ]
 
 
@@ -160,3 +170,24 @@ def test_create_grocery_list_validates_recipe_ids_payload() -> None:
 
     response = client.post(GROCERY_LIST_PATH, json={"recipe_ids": ["not-a-uuid"]})
     assert response.status_code == 422
+
+
+def test_create_grocery_list_forwards_viewer_user_id_header() -> None:
+    manager = FakeRecipeManager(ingredients_by_recipe={RECIPE_ONE: ["1 tomato"]})
+    grocery_service = FakeGroceryListAggregationService(ingredients=["1 tomato"])
+    client = build_client(manager, grocery_service)
+
+    response = client.post(
+        GROCERY_LIST_PATH,
+        json={"recipe_ids": [RECIPE_ONE]},
+        headers={"X-Viewer-User-Id": "44444444-4444-4444-4444-444444444444"},
+    )
+
+    assert response.status_code == 200
+    assert manager.calls == [
+        {
+            "recipe_ids": [RECIPE_ONE],
+            "include_test_data": False,
+            "viewer_user_id": "44444444-4444-4444-4444-444444444444",
+        }
+    ]

--- a/app/tests/unit/test_recipe_process_and_store_endpoint.py
+++ b/app/tests/unit/test_recipe_process_and_store_endpoint.py
@@ -20,6 +20,8 @@ class FakeRecipeProcessingService:
         source_url: str | None = None,
         enforce_deduplication: bool = True,
         is_test: bool = False,
+        is_public: bool = True,
+        created_by_user_id: str | None = None,
     ) -> tuple[str, None, bool]:
         self.calls.append(
             {
@@ -27,6 +29,8 @@ class FakeRecipeProcessingService:
                 "source_url": source_url,
                 "enforce_deduplication": enforce_deduplication,
                 "is_test": is_test,
+                "is_public": is_public,
+                "created_by_user_id": created_by_user_id,
             }
         )
         return RECIPE_ID, None, True
@@ -50,6 +54,8 @@ class FakeRecipeManager:
             "servings": "2",
             "total_time": "20 minutes",
             "source_url": SOURCE_URL,
+            "is_public": True,
+            "created_by_user_id": None,
             "created_at": None,
             "updated_at": None,
             "ingredients": ["200g spaghetti"],
@@ -92,6 +98,8 @@ def test_process_and_store_forwards_source_url() -> None:
             "source_url": SOURCE_URL,
             "enforce_deduplication": True,
             "is_test": False,
+            "is_public": True,
+            "created_by_user_id": None,
         }
     ]
     assert recipe_manager.calls == [
@@ -114,6 +122,7 @@ def test_process_and_store_accepts_source_url_alias() -> None:
 
     assert response.status_code == 200
     assert processing_service.calls[0]["source_url"] == SOURCE_URL
+    assert processing_service.calls[0]["is_public"] is True
 
 
 def test_process_and_store_returns_test_recipe_when_requested() -> None:
@@ -137,3 +146,25 @@ def test_process_and_store_returns_test_recipe_when_requested() -> None:
     assert body["recipe"]["id"] == RECIPE_ID
     assert processing_service.calls[0]["is_test"] is True
     assert recipe_manager.calls == [{"recipe_id": RECIPE_ID, "include_test_data": True}]
+
+
+def test_process_and_store_forwards_visibility_and_creator() -> None:
+    processing_service = FakeRecipeProcessingService()
+    recipe_manager = FakeRecipeManager()
+    client = build_client(processing_service, recipe_manager)
+
+    response = client.post(
+        PROCESS_AND_STORE_PATH,
+        json={
+            "raw_input": "Tomato Pasta recipe with ingredients and instructions.",
+            "isPublic": False,
+            "createdByUserId": "22222222-2222-2222-2222-222222222222",
+        },
+    )
+
+    assert response.status_code == 200
+    assert processing_service.calls[0]["is_public"] is False
+    assert (
+        processing_service.calls[0]["created_by_user_id"]
+        == "22222222-2222-2222-2222-222222222222"
+    )

--- a/app/tests/unit/test_recipe_process_and_store_endpoint.py
+++ b/app/tests/unit/test_recipe_process_and_store_endpoint.py
@@ -44,9 +44,14 @@ class FakeRecipeManager:
         self,
         recipe_id: str,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict:
         self.calls.append(
-            {"recipe_id": recipe_id, "include_test_data": include_test_data}
+            {
+                "recipe_id": recipe_id,
+                "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
+            }
         )
         return {
             "id": recipe_id,
@@ -103,7 +108,7 @@ def test_process_and_store_forwards_source_url() -> None:
         }
     ]
     assert recipe_manager.calls == [
-        {"recipe_id": RECIPE_ID, "include_test_data": False}
+        {"recipe_id": RECIPE_ID, "include_test_data": False, "viewer_user_id": None}
     ]
 
 
@@ -145,7 +150,9 @@ def test_process_and_store_returns_test_recipe_when_requested() -> None:
     assert body["recipe_id"] == RECIPE_ID
     assert body["recipe"]["id"] == RECIPE_ID
     assert processing_service.calls[0]["is_test"] is True
-    assert recipe_manager.calls == [{"recipe_id": RECIPE_ID, "include_test_data": True}]
+    assert recipe_manager.calls == [
+        {"recipe_id": RECIPE_ID, "include_test_data": True, "viewer_user_id": None}
+    ]
 
 
 def test_process_and_store_forwards_visibility_and_creator() -> None:
@@ -168,3 +175,10 @@ def test_process_and_store_forwards_visibility_and_creator() -> None:
         processing_service.calls[0]["created_by_user_id"]
         == "22222222-2222-2222-2222-222222222222"
     )
+    assert recipe_manager.calls == [
+        {
+            "recipe_id": RECIPE_ID,
+            "include_test_data": False,
+            "viewer_user_id": "22222222-2222-2222-2222-222222222222",
+        }
+    ]

--- a/app/tests/unit/test_recipe_processing_service_visibility.py
+++ b/app/tests/unit/test_recipe_processing_service_visibility.py
@@ -1,0 +1,125 @@
+from app.api.schemas import Recipe
+from app.services.recipe_processing_service import RecipeProcessingService
+
+
+class EchoCleanupService:
+    def cleanup_input(self, messy_input: str) -> str:
+        return messy_input
+
+
+class StaticRecipeExtractor:
+    def extract_recipe_from_raw_text(self, raw_text: str):
+        del raw_text
+        return (
+            Recipe(
+                title="Private Pasta",
+                ingredients=["200g pasta", "1 cup sauce"],
+                instructions=["Boil pasta", "Add sauce"],
+                servings="2",
+                total_time="20 minutes",
+            ),
+            None,
+        )
+
+
+class FakeRecipeManager:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def create_recipe_from_model(
+        self,
+        recipe: Recipe,
+        source_url: str | None = None,
+        embedding_type: str | None = None,
+        embedding: list[float] | None = None,
+        is_test_data: bool = False,
+        is_public: bool = True,
+        created_by_user_id: str | None = None,
+    ) -> str:
+        self.calls.append(
+            {
+                "recipe": recipe,
+                "source_url": source_url,
+                "embedding_type": embedding_type,
+                "embedding": embedding,
+                "is_test_data": is_test_data,
+                "is_public": is_public,
+                "created_by_user_id": created_by_user_id,
+            }
+        )
+        return "11111111-1111-1111-1111-111111111111"
+
+
+class FakeDedupeService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def find_duplicate(
+        self,
+        recipe: Recipe,
+        include_test_data: bool = False,
+        viewer_user_id: str | None = None,
+    ) -> tuple[bool, str | None, list[float] | None]:
+        self.calls.append(
+            {
+                "recipe": recipe,
+                "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
+            }
+        )
+        return False, None, [0.1, 0.2, 0.3]
+
+
+def test_process_raw_recipe_scopes_dedupe_to_creator_visibility() -> None:
+    recipe_manager = FakeRecipeManager()
+    dedupe_service = FakeDedupeService()
+    service = RecipeProcessingService(
+        cleanup_service=EchoCleanupService(),
+        extractor_service=StaticRecipeExtractor(),
+        recipe_manager=recipe_manager,
+        embeddings_service=object(),
+        dedupe_service=dedupe_service,
+    )
+
+    recipe_id, error, created = service.process_raw_recipe(
+        raw_input="Private Pasta\nIngredients:\n- pasta\nInstructions:\n1. Cook",
+        source_url="https://example.com/private-pasta",
+        enforce_deduplication=True,
+        is_test=False,
+        is_public=False,
+        created_by_user_id="22222222-2222-2222-2222-222222222222",
+    )
+
+    assert error is None
+    assert created is True
+    assert recipe_id == "11111111-1111-1111-1111-111111111111"
+    assert dedupe_service.calls == [
+        {
+            "recipe": Recipe(
+                title="Private Pasta",
+                ingredients=["200g pasta", "1 cup sauce"],
+                instructions=["Boil pasta", "Add sauce"],
+                servings="2",
+                total_time="20 minutes",
+            ),
+            "include_test_data": False,
+            "viewer_user_id": "22222222-2222-2222-2222-222222222222",
+        }
+    ]
+    assert recipe_manager.calls == [
+        {
+            "recipe": Recipe(
+                title="Private Pasta",
+                ingredients=["200g pasta", "1 cup sauce"],
+                instructions=["Boil pasta", "Add sauce"],
+                servings="2",
+                total_time="20 minutes",
+            ),
+            "source_url": "https://example.com/private-pasta",
+            "embedding_type": "title_ingredients",
+            "embedding": [0.1, 0.2, 0.3],
+            "is_test_data": False,
+            "is_public": False,
+            "created_by_user_id": "22222222-2222-2222-2222-222222222222",
+        }
+    ]

--- a/app/tests/unit/test_recipe_semantic_search_endpoint.py
+++ b/app/tests/unit/test_recipe_semantic_search_endpoint.py
@@ -55,6 +55,7 @@ class FakeRecipeManager:
         limit: int = 10,
         max_distance: float = 0.35,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         self.calls.append(
             {
@@ -63,6 +64,7 @@ class FakeRecipeManager:
                 "limit": limit,
                 "max_distance": max_distance,
                 "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
             }
         )
         if self.error:
@@ -74,12 +76,14 @@ class FakeRecipeManager:
         recipe_ids: list[str],
         max_ingredients: int = 8,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict[str, list[str]]:
         self.preview_calls.append(
             {
                 "recipe_ids": recipe_ids,
                 "max_ingredients": max_ingredients,
                 "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
             }
         )
         return {
@@ -92,12 +96,14 @@ class FakeRecipeManager:
         title_query: str,
         limit: int = 5,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         self.title_calls.append(
             {
                 "title_query": title_query,
                 "limit": limit,
                 "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
             }
         )
         if self.title_error:
@@ -195,6 +201,7 @@ def test_name_search_returns_results() -> None:
             "title_query": "chi",
             "limit": 10,
             "include_test_data": False,
+            "viewer_user_id": None,
         }
     ]
 
@@ -219,6 +226,21 @@ def test_name_search_returns_500_on_manager_error() -> None:
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Error performing recipe title search: db down"
+
+
+def test_name_search_forwards_viewer_user_id_header() -> None:
+    fake_manager = FakeRecipeManager()
+    fake_embeddings = FakeEmbeddingsService()
+    client = build_client(fake_manager, fake_embeddings)
+
+    response = client.get(
+        NAME_SEARCH_PATH,
+        params={"query": "chicken"},
+        headers={"X-Viewer-User-Id": "55555555-5555-5555-5555-555555555555"},
+    )
+
+    assert response.status_code == 200
+    assert fake_manager.title_calls[0]["viewer_user_id"] == "55555555-5555-5555-5555-555555555555"
 
 
 def test_semantic_search_reuses_cached_response(monkeypatch) -> None:
@@ -252,6 +274,35 @@ def test_semantic_search_reuses_cached_response(monkeypatch) -> None:
     assert second_response.json() == first_response.json()
     assert fake_embeddings.calls == ["lasagna"]
     assert len(fake_manager.calls) == 1
+
+
+def test_semantic_search_cache_is_scoped_by_viewer() -> None:
+    expected_results = [
+        {
+            "id": "recipe-1",
+            "name": "Classic Lasagne",
+            "distance": 0.08,
+        }
+    ]
+    fake_manager = FakeRecipeManager(results=expected_results)
+    fake_embeddings = FakeEmbeddingsService(embedding=[0.4, 0.5, 0.6])
+    client = build_client(fake_manager, fake_embeddings)
+
+    public_response = client.get(
+        SEMANTIC_SEARCH_PATH,
+        params={"query": "lasagna", "limit": 5},
+    )
+    viewer_response = client.get(
+        SEMANTIC_SEARCH_PATH,
+        params={"query": "lasagna", "limit": 5},
+        headers={"X-Viewer-User-Id": "44444444-4444-4444-4444-444444444444"},
+    )
+
+    assert public_response.status_code == 200
+    assert viewer_response.status_code == 200
+    assert fake_embeddings.calls == ["lasagna", "lasagna"]
+    assert fake_manager.calls[0]["viewer_user_id"] is None
+    assert fake_manager.calls[1]["viewer_user_id"] == "44444444-4444-4444-4444-444444444444"
 
 
 def test_semantic_search_returns_results() -> None:
@@ -289,6 +340,7 @@ def test_semantic_search_returns_results() -> None:
             "limit": expected_limit,
             "max_distance": settings.SEMANTIC_SEARCH_MAX_DISTANCE,
             "include_test_data": False,
+            "viewer_user_id": None,
         }
     ]
 
@@ -425,6 +477,7 @@ def test_semantic_search_applies_rerank_when_enabled(monkeypatch) -> None:
             "recipe_ids": [recipe_one, recipe_two],
             "max_ingredients": 8,
             "include_test_data": False,
+            "viewer_user_id": None,
         }
     ]
 

--- a/app/tests/unit/test_recipe_semantic_search_endpoint.py
+++ b/app/tests/unit/test_recipe_semantic_search_endpoint.py
@@ -240,7 +240,10 @@ def test_name_search_forwards_viewer_user_id_header() -> None:
     )
 
     assert response.status_code == 200
-    assert fake_manager.title_calls[0]["viewer_user_id"] == "55555555-5555-5555-5555-555555555555"
+    assert (
+        fake_manager.title_calls[0]["viewer_user_id"]
+        == "55555555-5555-5555-5555-555555555555"
+    )
 
 
 def test_semantic_search_reuses_cached_response(monkeypatch) -> None:
@@ -302,7 +305,10 @@ def test_semantic_search_cache_is_scoped_by_viewer() -> None:
     assert viewer_response.status_code == 200
     assert fake_embeddings.calls == ["lasagna", "lasagna"]
     assert fake_manager.calls[0]["viewer_user_id"] is None
-    assert fake_manager.calls[1]["viewer_user_id"] == "44444444-4444-4444-4444-444444444444"
+    assert (
+        fake_manager.calls[1]["viewer_user_id"]
+        == "44444444-4444-4444-4444-444444444444"
+    )
 
 
 def test_semantic_search_returns_results() -> None:

--- a/app/tests/unit/test_recipes_list_endpoint.py
+++ b/app/tests/unit/test_recipes_list_endpoint.py
@@ -44,6 +44,7 @@ class FakeRecipeManager:
         cursor_created_at: datetime | None = None,
         cursor_id: str | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         self.calls.append(
             {
@@ -51,6 +52,7 @@ class FakeRecipeManager:
                 "cursor_created_at": cursor_created_at,
                 "cursor_id": cursor_id,
                 "include_test_data": include_test_data,
+                "viewer_user_id": viewer_user_id,
             }
         )
         if self.error:
@@ -89,6 +91,7 @@ def test_list_recipes_uses_default_limit() -> None:
             "cursor_created_at": None,
             "cursor_id": None,
             "include_test_data": False,
+            "viewer_user_id": None,
         }
     ]
 
@@ -121,6 +124,7 @@ def test_list_recipes_returns_next_cursor_when_more_results_exist() -> None:
             "cursor_created_at": None,
             "cursor_id": None,
             "include_test_data": False,
+            "viewer_user_id": None,
         }
     ]
 
@@ -143,6 +147,7 @@ def test_list_recipes_passes_decoded_cursor_to_manager() -> None:
             "cursor_created_at": cursor_created_at,
             "cursor_id": RECIPE_ONE,
             "include_test_data": False,
+            "viewer_user_id": None,
         }
     ]
 
@@ -166,3 +171,19 @@ def test_list_recipes_returns_500_when_manager_errors() -> None:
 
     assert response.status_code == 500
     assert response.json()["detail"] == "Error listing recipes"
+
+
+def test_list_recipes_forwards_viewer_user_id_header() -> None:
+    created_at = datetime(2026, 3, 1, 12, 30, 0)
+    manager = FakeRecipeManager(
+        recipes_page=[_build_recipe(RECIPE_ONE, "Tomato Pasta", created_at)]
+    )
+    client = build_client(manager)
+
+    response = client.get(
+        LIST_RECIPES_PATH,
+        headers={"X-Viewer-User-Id": "33333333-3333-3333-3333-333333333333"},
+    )
+
+    assert response.status_code == 200
+    assert manager.calls[0]["viewer_user_id"] == "33333333-3333-3333-3333-333333333333"

--- a/app/tests/unit/test_recipes_list_endpoint.py
+++ b/app/tests/unit/test_recipes_list_endpoint.py
@@ -20,6 +20,8 @@ def _build_recipe(recipe_id: str, title: str, created_at: datetime) -> dict:
         "servings": "2",
         "total_time": "20 minutes",
         "source_url": "https://example.com/recipe",
+        "is_public": True,
+        "created_by_user_id": None,
         "is_test_data": False,
         "created_at": created_at,
         "updated_at": created_at,

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -41,6 +41,8 @@ In Supabase:
    OAuth client redirect URIs.
 4. Run [`docs/supabase-auth-profile-schema.sql`](../../docs/supabase-auth-profile-schema.sql)
    in the Supabase SQL editor to create `public.profiles`.
+5. Run [`docs/recipe-ownership-schema.sql`](../../docs/recipe-ownership-schema.sql)
+   in the Supabase SQL editor to add recipe visibility + creator ownership columns.
 
 ## Current Routes
 

--- a/apps/web/src/app/api/recipes/[recipeId]/route.test.ts
+++ b/apps/web/src/app/api/recipes/[recipeId]/route.test.ts
@@ -3,16 +3,26 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { deleteRecipeApiMock, getRecipeApiMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
+const {
+  deleteRecipeApiMock,
+  getRecipeApiMock,
+  isForkfolioApiErrorMock,
+  getOptionalViewerUserIdMock,
+} = vi.hoisted(() => ({
   deleteRecipeApiMock: vi.fn(),
   getRecipeApiMock: vi.fn(),
   isForkfolioApiErrorMock: vi.fn(),
+  getOptionalViewerUserIdMock: vi.fn(),
 }));
 
 vi.mock("@/lib/forkfolio-api", () => ({
   deleteRecipe: deleteRecipeApiMock,
   getRecipe: getRecipeApiMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getOptionalViewerUserId: getOptionalViewerUserIdMock,
 }));
 
 import { DELETE, GET } from "./route";
@@ -22,7 +32,9 @@ describe("/api/recipes/[recipeId]", () => {
     deleteRecipeApiMock.mockReset();
     getRecipeApiMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    getOptionalViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getOptionalViewerUserIdMock.mockResolvedValue(null);
   });
 
   it("returns 400 when recipe id is blank", async () => {
@@ -46,6 +58,8 @@ describe("/api/recipes/[recipeId]", () => {
         servings: "2",
         total_time: "20 minutes",
         source_url: null,
+        is_public: true,
+        created_by_user_id: null,
         created_at: null,
         updated_at: null,
         ingredients: ["Tomatoes"],
@@ -62,7 +76,36 @@ describe("/api/recipes/[recipeId]", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=300, stale-while-revalidate=900",
     );
-    expect(getRecipeApiMock).toHaveBeenCalledWith("recipe-1");
+    expect(getRecipeApiMock).toHaveBeenCalledWith("recipe-1", null);
+  });
+
+  it("uses private no-store cache and forwards viewer id when signed in", async () => {
+    getOptionalViewerUserIdMock.mockResolvedValue("viewer-123");
+    getRecipeApiMock.mockResolvedValue({
+      success: true,
+      recipe: {
+        id: "recipe-1",
+        title: "Tomato Soup",
+        servings: "2",
+        total_time: "20 minutes",
+        source_url: null,
+        is_public: false,
+        created_by_user_id: "viewer-123",
+        created_at: null,
+        updated_at: null,
+        ingredients: ["Tomatoes"],
+        instructions: ["Cook"],
+      },
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/recipes/recipe-1");
+    const response = await GET(request, {
+      params: Promise.resolve({ recipeId: "recipe-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(getRecipeApiMock).toHaveBeenCalledWith("recipe-1", "viewer-123");
   });
 
   it("maps Forkfolio API errors", async () => {

--- a/apps/web/src/app/api/recipes/[recipeId]/route.ts
+++ b/apps/web/src/app/api/recipes/[recipeId]/route.ts
@@ -5,6 +5,7 @@ import {
   getRecipe,
   isForkfolioApiError,
 } from "@/lib/forkfolio-api";
+import { getOptionalViewerUserId } from "@/lib/supabase/viewer";
 
 const RECIPE_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=900";
 
@@ -41,13 +42,14 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   if ("detail" in parsedRecipeId) {
     return NextResponse.json({ detail: parsedRecipeId.detail }, { status: parsedRecipeId.status });
   }
+  const viewerUserId = await getOptionalViewerUserId();
 
   try {
-    const response = await getRecipe(parsedRecipeId.recipeId);
+    const response = await getRecipe(parsedRecipeId.recipeId, viewerUserId);
     return NextResponse.json(response, {
       status: 200,
       headers: {
-        "Cache-Control": RECIPE_CACHE_CONTROL,
+        "Cache-Control": viewerUserId ? "private, no-store" : RECIPE_CACHE_CONTROL,
       },
     });
   } catch (error) {

--- a/apps/web/src/app/api/recipes/process/route.test.ts
+++ b/apps/web/src/app/api/recipes/process/route.test.ts
@@ -3,14 +3,43 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { processRecipeMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
-  processRecipeMock: vi.fn(),
-  isForkfolioApiErrorMock: vi.fn(),
-}));
+const {
+  processRecipeMock,
+  isForkfolioApiErrorMock,
+  createClientMock,
+  getUserMock,
+  hasSupabaseAuthConfigMock,
+} = vi.hoisted(() => {
+  const processRecipeMock = vi.fn();
+  const isForkfolioApiErrorMock = vi.fn();
+  const getUserMock = vi.fn();
+  const createClientMock = vi.fn(async () => ({
+    auth: {
+      getUser: getUserMock,
+    },
+  }));
+  const hasSupabaseAuthConfigMock = vi.fn();
+
+  return {
+    processRecipeMock,
+    isForkfolioApiErrorMock,
+    createClientMock,
+    getUserMock,
+    hasSupabaseAuthConfigMock,
+  };
+});
 
 vi.mock("@/lib/forkfolio-api", () => ({
   processRecipe: processRecipeMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: createClientMock,
+}));
+
+vi.mock("@/lib/supabase/config", () => ({
+  hasSupabaseAuthConfig: hasSupabaseAuthConfigMock,
 }));
 
 import { POST } from "./route";
@@ -19,7 +48,15 @@ describe("POST /api/recipes/process", () => {
   beforeEach(() => {
     processRecipeMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    createClientMock.mockClear();
+    getUserMock.mockReset();
+    hasSupabaseAuthConfigMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    hasSupabaseAuthConfigMock.mockReturnValue(true);
+    getUserMock.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+      error: null,
+    });
   });
 
   it("returns 400 when raw_input is missing", async () => {
@@ -38,6 +75,7 @@ describe("POST /api/recipes/process", () => {
       detail: "Missing raw_input in request payload.",
     });
     expect(processRecipeMock).not.toHaveBeenCalled();
+    expect(createClientMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 when JSON body is not an object", async () => {
@@ -54,6 +92,7 @@ describe("POST /api/recipes/process", () => {
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ detail: "Invalid JSON payload." });
     expect(processRecipeMock).not.toHaveBeenCalled();
+    expect(createClientMock).not.toHaveBeenCalled();
   });
 
   it("returns 422 when raw_input is too short", async () => {
@@ -72,6 +111,7 @@ describe("POST /api/recipes/process", () => {
       detail: "raw_input must be at least 10 characters.",
     });
     expect(processRecipeMock).not.toHaveBeenCalled();
+    expect(createClientMock).not.toHaveBeenCalled();
   });
 
   it("trims raw_input and forwards request", async () => {
@@ -86,6 +126,8 @@ describe("POST /api/recipes/process", () => {
         servings: null,
         total_time: null,
         source_url: null,
+        is_public: true,
+        created_by_user_id: "user-123",
         created_at: null,
         updated_at: null,
         ingredients: [],
@@ -112,6 +154,8 @@ describe("POST /api/recipes/process", () => {
       raw_input: "raw recipe text",
       source_url: "https://example.com/recipe",
       enforce_deduplication: true,
+      is_public: true,
+      created_by_user_id: "user-123",
       isTest: false,
     });
   });
@@ -135,6 +179,92 @@ describe("POST /api/recipes/process", () => {
       detail: "source_url must use http or https.",
     });
     expect(processRecipeMock).not.toHaveBeenCalled();
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when Supabase Auth is not configured", async () => {
+    hasSupabaseAuthConfigMock.mockReturnValue(false);
+
+    const request = new NextRequest("http://localhost:3000/api/recipes/process", {
+      method: "POST",
+      body: JSON.stringify({ raw_input: "valid input content" }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      detail: "Recipe creation requires Supabase Auth configuration.",
+    });
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(processRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the user is not signed in", async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/recipes/process", {
+      method: "POST",
+      body: JSON.stringify({ raw_input: "valid input content" }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ detail: "Sign in to create recipes." });
+    expect(processRecipeMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards private visibility when requested", async () => {
+    processRecipeMock.mockResolvedValue({
+      success: true,
+      recipe_id: "recipe-42",
+      created: true,
+      recipe: {
+        id: "recipe-42",
+        title: "Recipe",
+        servings: null,
+        total_time: null,
+        source_url: null,
+        is_public: false,
+        created_by_user_id: "user-123",
+        created_at: null,
+        updated_at: null,
+        ingredients: [],
+        instructions: [],
+      },
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/recipes/process", {
+      method: "POST",
+      body: JSON.stringify({
+        raw_input: "valid input content",
+        isPublic: false,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(processRecipeMock).toHaveBeenCalledWith({
+      raw_input: "valid input content",
+      enforce_deduplication: true,
+      is_public: false,
+      created_by_user_id: "user-123",
+      isTest: false,
+    });
   });
 
   it("maps Forkfolio API errors", async () => {

--- a/apps/web/src/app/api/recipes/process/route.ts
+++ b/apps/web/src/app/api/recipes/process/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { isForkfolioApiError, processRecipe } from "@/lib/forkfolio-api";
+import { hasSupabaseAuthConfig } from "@/lib/supabase/config";
+import { createClient } from "@/lib/supabase/server";
 import {
   MIN_RECIPE_INPUT_LENGTH,
   type ProcessRecipeRequest,
@@ -11,6 +13,8 @@ type ProcessRoutePayload = {
   source_url?: unknown;
   sourceUrl?: unknown;
   enforce_deduplication?: unknown;
+  isPublic?: unknown;
+  is_public?: unknown;
   isTest?: unknown;
   is_test?: unknown;
 };
@@ -77,6 +81,12 @@ function normalizePayload(payload: ProcessRoutePayload): NormalizedPayloadResult
       : typeof payload.is_test === "boolean"
         ? payload.is_test
         : false;
+  const isPublicValue =
+    typeof payload.isPublic === "boolean"
+      ? payload.isPublic
+      : typeof payload.is_public === "boolean"
+        ? payload.is_public
+        : true;
 
   return {
     payload: {
@@ -85,6 +95,7 @@ function normalizePayload(payload: ProcessRoutePayload): NormalizedPayloadResult
         typeof payload.enforce_deduplication === "boolean"
           ? payload.enforce_deduplication
           : true,
+      is_public: isPublicValue,
       isTest: isTestValue,
       ...(normalizedSourceUrl ? { source_url: normalizedSourceUrl } : {}),
     },
@@ -113,8 +124,24 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  if (!hasSupabaseAuthConfig()) {
+    return NextResponse.json(
+      { detail: "Recipe creation requires Supabase Auth configuration." },
+      { status: 503 },
+    );
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) {
+    return NextResponse.json({ detail: "Sign in to create recipes." }, { status: 401 });
+  }
+
   try {
-    const response = await processRecipe(normalizedPayload.payload);
+    const response = await processRecipe({
+      ...normalizedPayload.payload,
+      created_by_user_id: data.user.id,
+    });
     return NextResponse.json(response, {
       status: 200,
       headers: {

--- a/apps/web/src/app/api/recipes/route.test.ts
+++ b/apps/web/src/app/api/recipes/route.test.ts
@@ -3,14 +3,21 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listRecipesMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
-  listRecipesMock: vi.fn(),
-  isForkfolioApiErrorMock: vi.fn(),
-}));
+const { listRecipesMock, isForkfolioApiErrorMock, getOptionalViewerUserIdMock } = vi.hoisted(
+  () => ({
+    listRecipesMock: vi.fn(),
+    isForkfolioApiErrorMock: vi.fn(),
+    getOptionalViewerUserIdMock: vi.fn(),
+  }),
+);
 
 vi.mock("@/lib/forkfolio-api", () => ({
   listRecipes: listRecipesMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getOptionalViewerUserId: getOptionalViewerUserIdMock,
 }));
 
 import { GET } from "./route";
@@ -19,7 +26,9 @@ describe("GET /api/recipes", () => {
   beforeEach(() => {
     listRecipesMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    getOptionalViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getOptionalViewerUserIdMock.mockResolvedValue(null);
   });
 
   it("uses default limit when limit is missing", async () => {
@@ -40,7 +49,7 @@ describe("GET /api/recipes", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );
-    expect(listRecipesMock).toHaveBeenCalledWith(12, undefined);
+    expect(listRecipesMock).toHaveBeenCalledWith(12, undefined, null);
   });
 
   it("forwards cursor and caps limit at 200", async () => {
@@ -59,7 +68,7 @@ describe("GET /api/recipes", () => {
     );
     await GET(request);
 
-    expect(listRecipesMock).toHaveBeenCalledWith(200, "cursor-1");
+    expect(listRecipesMock).toHaveBeenCalledWith(200, "cursor-1", null);
   });
 
   it("uses default limit when limit is invalid", async () => {
@@ -78,7 +87,27 @@ describe("GET /api/recipes", () => {
     );
     await GET(request);
 
-    expect(listRecipesMock).toHaveBeenCalledWith(12, undefined);
+    expect(listRecipesMock).toHaveBeenCalledWith(12, undefined, null);
+  });
+
+  it("forwards viewer user id and disables shared caching", async () => {
+    getOptionalViewerUserIdMock.mockResolvedValue("viewer-123");
+    listRecipesMock.mockResolvedValue({
+      recipes: [],
+      count: 0,
+      limit: 12,
+      cursor: null,
+      next_cursor: null,
+      has_more: false,
+      success: true,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/recipes");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(listRecipesMock).toHaveBeenCalledWith(12, undefined, "viewer-123");
   });
 
   it("maps Forkfolio API errors", async () => {

--- a/apps/web/src/app/api/recipes/route.ts
+++ b/apps/web/src/app/api/recipes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { isForkfolioApiError, listRecipes } from "@/lib/forkfolio-api";
+import { getOptionalViewerUserId } from "@/lib/supabase/viewer";
 
 const DEFAULT_LIMIT = 12;
 const RECIPES_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
@@ -21,13 +22,14 @@ export async function GET(request: NextRequest) {
   const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
   const rawCursor = request.nextUrl.searchParams.get("cursor");
   const cursor = rawCursor?.trim() ? rawCursor.trim() : undefined;
+  const viewerUserId = await getOptionalViewerUserId();
 
   try {
-    const response = await listRecipes(limit, cursor);
+    const response = await listRecipes(limit, cursor, viewerUserId);
     return NextResponse.json(response, {
       status: 200,
       headers: {
-        "Cache-Control": RECIPES_CACHE_CONTROL,
+        "Cache-Control": viewerUserId ? "private, no-store" : RECIPES_CACHE_CONTROL,
       },
     });
   } catch (error) {

--- a/apps/web/src/app/api/search/names/route.test.ts
+++ b/apps/web/src/app/api/search/names/route.test.ts
@@ -3,14 +3,23 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { searchRecipesByNameMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
+const {
+  searchRecipesByNameMock,
+  isForkfolioApiErrorMock,
+  getOptionalViewerUserIdMock,
+} = vi.hoisted(() => ({
   searchRecipesByNameMock: vi.fn(),
   isForkfolioApiErrorMock: vi.fn(),
+  getOptionalViewerUserIdMock: vi.fn(),
 }));
 
 vi.mock("@/lib/forkfolio-api", () => ({
   searchRecipesByName: searchRecipesByNameMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getOptionalViewerUserId: getOptionalViewerUserIdMock,
 }));
 
 import { GET } from "./route";
@@ -19,7 +28,9 @@ describe("GET /api/search/names", () => {
   beforeEach(() => {
     searchRecipesByNameMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    getOptionalViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getOptionalViewerUserIdMock.mockResolvedValue(null);
   });
 
   it("returns 400 when query is missing", async () => {
@@ -64,7 +75,27 @@ describe("GET /api/search/names", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=15, stale-while-revalidate=60",
     );
-    expect(searchRecipesByNameMock).toHaveBeenCalledWith("chi", 10);
+    expect(searchRecipesByNameMock).toHaveBeenCalledWith("chi", 10, null);
+  });
+
+  it("forwards viewer user id and disables shared caching", async () => {
+    getOptionalViewerUserIdMock.mockResolvedValue("viewer-123");
+    searchRecipesByNameMock.mockResolvedValue({
+      query: "chi",
+      count: 1,
+      results: [{ id: "recipe-1", name: "Chicken Tikka Masala", distance: null }],
+      success: true,
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/search/names?query=chi&limit=10",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(searchRecipesByNameMock).toHaveBeenCalledWith("chi", 10, "viewer-123");
   });
 
   it("maps Forkfolio API errors", async () => {

--- a/apps/web/src/app/api/search/names/route.ts
+++ b/apps/web/src/app/api/search/names/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { isForkfolioApiError, searchRecipesByName } from "@/lib/forkfolio-api";
+import { getOptionalViewerUserId } from "@/lib/supabase/viewer";
 
 const DEFAULT_LIMIT = 10;
 const NAME_SEARCH_CACHE_CONTROL = "public, max-age=15, stale-while-revalidate=60";
@@ -20,6 +21,7 @@ function parseLimit(rawLimit: string | null): number {
 export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.get("query")?.trim() ?? "";
   const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+  const viewerUserId = await getOptionalViewerUserId();
 
   if (!query) {
     return NextResponse.json(
@@ -35,11 +37,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const response = await searchRecipesByName(query, limit);
+    const response = await searchRecipesByName(query, limit, viewerUserId);
     return NextResponse.json(response, {
       status: 200,
       headers: {
-        "Cache-Control": NAME_SEARCH_CACHE_CONTROL,
+        "Cache-Control": viewerUserId ? "private, no-store" : NAME_SEARCH_CACHE_CONTROL,
       },
     });
   } catch (error) {

--- a/apps/web/src/app/api/search/route.test.ts
+++ b/apps/web/src/app/api/search/route.test.ts
@@ -3,14 +3,20 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { searchRecipesMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
-  searchRecipesMock: vi.fn(),
-  isForkfolioApiErrorMock: vi.fn(),
-}));
+const { searchRecipesMock, isForkfolioApiErrorMock, getOptionalViewerUserIdMock } =
+  vi.hoisted(() => ({
+    searchRecipesMock: vi.fn(),
+    isForkfolioApiErrorMock: vi.fn(),
+    getOptionalViewerUserIdMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/forkfolio-api", () => ({
   searchRecipes: searchRecipesMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getOptionalViewerUserId: getOptionalViewerUserIdMock,
 }));
 
 import { GET } from "./route";
@@ -19,7 +25,9 @@ describe("GET /api/search", () => {
   beforeEach(() => {
     searchRecipesMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    getOptionalViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getOptionalViewerUserIdMock.mockResolvedValue(null);
   });
 
   it("returns 400 when query is missing", async () => {
@@ -50,7 +58,7 @@ describe("GET /api/search", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=60, stale-while-revalidate=300",
     );
-    expect(searchRecipesMock).toHaveBeenCalledWith("pasta", 50, false);
+    expect(searchRecipesMock).toHaveBeenCalledWith("pasta", 50, false, null);
   });
 
   it("uses default limit when limit is invalid", async () => {
@@ -67,7 +75,7 @@ describe("GET /api/search", () => {
 
     await GET(request);
 
-    expect(searchRecipesMock).toHaveBeenCalledWith("soup", 12, false);
+    expect(searchRecipesMock).toHaveBeenCalledWith("soup", 12, false, null);
   });
 
   it("passes rerank flag through when explicitly enabled", async () => {
@@ -84,7 +92,24 @@ describe("GET /api/search", () => {
 
     await GET(request);
 
-    expect(searchRecipesMock).toHaveBeenCalledWith("salad", 12, true);
+    expect(searchRecipesMock).toHaveBeenCalledWith("salad", 12, true, null);
+  });
+
+  it("forwards viewer user id and disables shared caching", async () => {
+    getOptionalViewerUserIdMock.mockResolvedValue("viewer-123");
+    searchRecipesMock.mockResolvedValue({
+      query: "salad",
+      count: 0,
+      results: [],
+      success: true,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/search?query=salad");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(searchRecipesMock).toHaveBeenCalledWith("salad", 12, false, "viewer-123");
   });
 
   it("maps Forkfolio API errors", async () => {

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { isForkfolioApiError, searchRecipes } from "@/lib/forkfolio-api";
+import { getOptionalViewerUserId } from "@/lib/supabase/viewer";
 
 const DEFAULT_LIMIT = 12;
 const SEARCH_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
@@ -30,6 +31,7 @@ export async function GET(request: NextRequest) {
   const query = request.nextUrl.searchParams.get("query")?.trim() ?? "";
   const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
   const rerank = parseRerank(request.nextUrl.searchParams.get("rerank"));
+  const viewerUserId = await getOptionalViewerUserId();
 
   if (!query) {
     return NextResponse.json(
@@ -39,11 +41,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const response = await searchRecipes(query, limit, rerank);
+    const response = await searchRecipes(query, limit, rerank, viewerUserId);
     return NextResponse.json(response, {
       status: 200,
       headers: {
-        "Cache-Control": SEARCH_CACHE_CONTROL,
+        "Cache-Control": viewerUserId ? "private, no-store" : SEARCH_CACHE_CONTROL,
       },
     });
   } catch (error) {

--- a/apps/web/src/app/books/[bookId]/page.tsx
+++ b/apps/web/src/app/books/[bookId]/page.tsx
@@ -199,6 +199,7 @@ export default async function RecipeBookDetailPage({ params }: RecipeBookDetailP
                         <RecipeMetadataBadges
                           servings={recipe.servings}
                           totalTime={recipe.total_time}
+                          isPublic={recipe.is_public}
                         />
                       </CardHeader>
                       <CardContent className="space-y-4">

--- a/apps/web/src/app/browse/components/browse-results-grid.tsx
+++ b/apps/web/src/app/browse/components/browse-results-grid.tsx
@@ -50,7 +50,11 @@ function SearchCard({
   const recipeId = result.id;
   const ingredients = recipe?.ingredients?.slice(0, 3) ?? [];
   const canOpen = Boolean(recipeId);
-  const hasRecipeMetadata = Boolean(recipe?.total_time?.trim() || recipe?.servings?.trim());
+  const hasRecipeMetadata = Boolean(
+    recipe?.total_time?.trim() ||
+      recipe?.servings?.trim() ||
+      typeof recipe?.is_public === "boolean",
+  );
 
   return (
     <Card
@@ -88,7 +92,11 @@ function SearchCard({
 
           {recipe ? (
             hasRecipeMetadata ? (
-              <RecipeMetadataBadges servings={recipe.servings} totalTime={recipe.total_time} />
+              <RecipeMetadataBadges
+                servings={recipe.servings}
+                totalTime={recipe.total_time}
+                isPublic={recipe.is_public}
+              />
             ) : (
               <span className="text-muted-foreground">No time or serving info yet.</span>
             )

--- a/apps/web/src/app/browse/components/recipe-modal.tsx
+++ b/apps/web/src/app/browse/components/recipe-modal.tsx
@@ -63,7 +63,11 @@ export function RecipeModal({
             )}
 
             {recipe ? (
-              <RecipeMetadataBadges servings={recipe.servings} totalTime={recipe.total_time} />
+              <RecipeMetadataBadges
+                servings={recipe.servings}
+                totalTime={recipe.total_time}
+                isPublic={recipe.is_public}
+              />
             ) : null}
           </div>
 

--- a/apps/web/src/app/recipes/[recipeId]/page.tsx
+++ b/apps/web/src/app/recipes/[recipeId]/page.tsx
@@ -83,6 +83,7 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
             servings={recipe.servings}
             totalTime={recipe.total_time}
             sourceUrl={recipe.source_url}
+            isPublic={recipe.is_public}
             showSourceUrl
           />
 
@@ -92,6 +93,16 @@ export default async function RecipeDetailPage({ params }: RecipePageProps) {
                 {recipe.created_at ? <span>Created: {recipe.created_at}</span> : null}
                 {recipe.updated_at ? <span>Updated: {recipe.updated_at}</span> : null}
               </div>
+              {recipe.created_by_user_id ? (
+                <div className="rounded-2xl border border-border/70 bg-card/55 px-4 py-3">
+                  <p className="text-xs font-semibold tracking-[0.08em] text-foreground/70 uppercase">
+                    Creator ID
+                  </p>
+                  <p className="mt-1 break-all text-sm text-foreground/85">
+                    {recipe.created_by_user_id}
+                  </p>
+                </div>
+              ) : null}
               <div>
                 <RecipeBagToggleButton
                   recipe={{

--- a/apps/web/src/app/recipes/new/page.test.tsx
+++ b/apps/web/src/app/recipes/new/page.test.tsx
@@ -78,6 +78,8 @@ describe("/recipes/new page", () => {
             servings: null,
             total_time: null,
             source_url: null,
+            is_public: true,
+            created_by_user_id: "user-123",
             created_at: null,
             updated_at: null,
             ingredients: [],
@@ -146,6 +148,8 @@ describe("/recipes/new page", () => {
             servings: "2",
             total_time: "20 minutes",
             source_url: null,
+            is_public: true,
+            created_by_user_id: "user-123",
             created_at: null,
             updated_at: null,
             ingredients: ["200g spaghetti", "2 cloves garlic"],
@@ -180,8 +184,52 @@ describe("/recipes/new page", () => {
     expect(savePayload).toMatchObject({
       source_url: "https://example.com/pasta",
       enforce_deduplication: true,
+      isPublic: true,
       isTest: false,
     });
+  });
+
+  it("sends private visibility when toggled off", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          recipe_id: "recipe-private-123",
+          created: true,
+          message: "Recipe processed and stored successfully",
+          recipe: {
+            id: "recipe-private-123",
+            title: "Private Pasta",
+            servings: null,
+            total_time: null,
+            source_url: null,
+            is_public: false,
+            created_by_user_id: "user-123",
+            created_at: null,
+            updated_at: null,
+            ingredients: [],
+            instructions: [],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    render(<NewRecipePage />);
+
+    await user.click(screen.getByRole("switch", { name: /toggle recipe visibility/i }));
+    await user.click(screen.getByRole("tab", { name: /Paste Text/i }));
+    await user.type(
+      screen.getByLabelText("Raw recipe text"),
+      "Private Pasta with olive oil, garlic, and noodles.",
+    );
+    await user.click(screen.getByRole("button", { name: /Process & Save Recipe/i }));
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const payload = JSON.parse(String(requestInit.body));
+    expect(payload.isPublic).toBe(false);
   });
 
   it("shows error state when API returns failure", async () => {
@@ -205,5 +253,32 @@ describe("/recipes/new page", () => {
 
     expect(await screen.findByText("Unable to process recipe")).toBeInTheDocument();
     expect(await screen.findByText("Backend unavailable")).toBeInTheDocument();
+  });
+
+  it("shows a sign-in recovery message when save is unauthorized", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Sign in to create recipes." }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    render(<NewRecipePage />);
+
+    await user.click(screen.getByRole("tab", { name: /Paste Text/i }));
+    await user.type(
+      screen.getByLabelText("Raw recipe text"),
+      "Long enough recipe text for API processing",
+    );
+    await user.click(screen.getByRole("button", { name: /Process & Save Recipe/i }));
+
+    expect(await screen.findByText("Unable to process recipe")).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        "Sign in to create recipes. Use the profile button in the header and try again.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/recipes/new/page.tsx
+++ b/apps/web/src/app/recipes/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, Loader2, Sparkles } from "lucide-react";
+import { ArrowRight, Globe, Loader2, Lock, Sparkles } from "lucide-react";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 
 import { ForkfolioHeader } from "@/components/forkfolio-header";
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { consumeExperimentRecipeDraft } from "@/lib/experiment-recipe-draft";
@@ -58,6 +59,13 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+function getSaveErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof BrowserApiError && error.status === 401) {
+    return "Sign in to create recipes. Use the profile button in the header and try again.";
+  }
+  return getErrorMessage(error, fallback);
+}
+
 async function readErrorPayload(response: Response): Promise<ErrorPayload | null> {
   try {
     return (await response.json()) as ErrorPayload;
@@ -68,6 +76,7 @@ async function readErrorPayload(response: Response): Promise<ErrorPayload | null
 
 async function processRecipeClient(
   rawInput: string,
+  isPublic: boolean,
   sourceUrl?: string,
 ): Promise<ProcessRecipeResponse> {
   const response = await fetch("/api/recipes/process", {
@@ -80,6 +89,7 @@ async function processRecipeClient(
     body: JSON.stringify({
       raw_input: rawInput,
       enforce_deduplication: true,
+      isPublic,
       isTest: false,
       ...(sourceUrl ? { source_url: sourceUrl } : {}),
     }),
@@ -203,6 +213,7 @@ export default function NewRecipePage() {
   const [sourceUrl, setSourceUrl] = useState("");
   const [textModeSourceUrl, setTextModeSourceUrl] = useState<string | null>(null);
   const [inputMode, setInputMode] = useState<InputMode>("url");
+  const [isPublic, setIsPublic] = useState(true);
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [isSavingPreview, setIsSavingPreview] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -261,6 +272,7 @@ export default function NewRecipePage() {
     try {
       const response = await processRecipeClient(
         normalizedInput,
+        isPublic,
         textModeSourceUrl ?? undefined,
       );
       setResult(response);
@@ -268,7 +280,7 @@ export default function NewRecipePage() {
         setErrorMessage(response.error || "Recipe processing failed.");
       }
     } catch (error) {
-      setErrorMessage(getErrorMessage(error, "Recipe processing failed."));
+      setErrorMessage(getSaveErrorMessage(error, "Recipe processing failed."));
     } finally {
       setIsSubmitting(false);
     }
@@ -310,7 +322,11 @@ export default function NewRecipePage() {
     setResult(null);
 
     try {
-      const response = await processRecipeClient(normalizedInput, sourceUrlForSave);
+      const response = await processRecipeClient(
+        normalizedInput,
+        isPublic,
+        sourceUrlForSave,
+      );
       setResult(response);
       if (response.success) {
         setPreviewResult(null);
@@ -320,7 +336,7 @@ export default function NewRecipePage() {
         setErrorMessage(response.error || "Recipe processing failed.");
       }
     } catch (error) {
-      setErrorMessage(getErrorMessage(error, "Recipe processing failed."));
+      setErrorMessage(getSaveErrorMessage(error, "Recipe processing failed."));
     } finally {
       setIsSavingPreview(false);
     }
@@ -337,6 +353,7 @@ export default function NewRecipePage() {
     setRawInput("");
     setSourceUrl("");
     setInputMode("url");
+    setIsPublic(true);
     setTextModeSourceUrl(null);
     setIsPreviewing(false);
     setIsSavingPreview(false);
@@ -385,6 +402,52 @@ export default function NewRecipePage() {
             description="Import from a URL or paste plain text. Use one path at a time for a cleaner save flow."
             contentClassName="max-w-4xl"
           >
+              <Card className="border-border/80 bg-background/82 shadow-none">
+                <CardContent className="pt-6">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                        {isPublic ? (
+                          <Globe className="size-4 text-primary" />
+                        ) : (
+                          <Lock className="size-4 text-primary" />
+                        )}
+                        Recipe visibility
+                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        {isPublic
+                          ? "Public recipes are saved with a public visibility marker."
+                          : "Private recipes stay labeled private and linked to your account."}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                        <Badge
+                          variant="outline"
+                          className="rounded-full border-border/70 bg-background/70 px-2.5 py-0.5"
+                        >
+                          Sign-in required to save
+                        </Badge>
+                        <span>Use the profile button in the header before importing.</span>
+                      </div>
+                    </div>
+
+                    <Label
+                      htmlFor="recipe-visibility"
+                      className="min-h-11 cursor-pointer justify-between gap-4 self-start rounded-full border border-border/80 bg-background px-4 py-2.5"
+                    >
+                      <span className="text-sm font-medium">
+                        {isPublic ? "Public" : "Private"}
+                      </span>
+                      <Switch
+                        id="recipe-visibility"
+                        checked={isPublic}
+                        onCheckedChange={setIsPublic}
+                        aria-label="Toggle recipe visibility"
+                      />
+                    </Label>
+                  </div>
+                </CardContent>
+              </Card>
+
               <Tabs
                 value={inputMode}
                 onValueChange={(value) => {

--- a/apps/web/src/components/recipe-metadata-badges.tsx
+++ b/apps/web/src/components/recipe-metadata-badges.tsx
@@ -1,4 +1,4 @@
-import { Clock3, LinkIcon, Users2 } from "lucide-react";
+import { Clock3, Globe, LinkIcon, Lock, Users2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -7,6 +7,7 @@ type RecipeMetadataBadgesProps = {
   servings?: string | null;
   totalTime?: string | null;
   sourceUrl?: string | null;
+  isPublic?: boolean | null;
   showSourceUrl?: boolean;
   className?: string;
 };
@@ -19,6 +20,7 @@ export function RecipeMetadataBadges({
   servings,
   totalTime,
   sourceUrl,
+  isPublic,
   showSourceUrl = false,
   className,
 }: RecipeMetadataBadgesProps) {
@@ -28,6 +30,7 @@ export function RecipeMetadataBadges({
   const showAnyBadge =
     Boolean(normalizedServings) ||
     Boolean(normalizedTotalTime) ||
+    typeof isPublic === "boolean" ||
     (showSourceUrl && Boolean(normalizedSourceUrl));
 
   if (!showAnyBadge) {
@@ -47,6 +50,17 @@ export function RecipeMetadataBadges({
         <Badge variant="secondary" className="min-w-0 max-w-full gap-1.5">
           <Users2 className="size-3.5 shrink-0" />
           <span className="truncate">{normalizedServings}</span>
+        </Badge>
+      ) : null}
+
+      {typeof isPublic === "boolean" ? (
+        <Badge variant="secondary" className="min-w-0 max-w-full gap-1.5">
+          {isPublic ? (
+            <Globe className="size-3.5 shrink-0" />
+          ) : (
+            <Lock className="size-3.5 shrink-0" />
+          )}
+          <span className="truncate">{isPublic ? "Public" : "Private"}</span>
         </Badge>
       ) : null}
 

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-6 w-11 shrink-0 items-center rounded-full border border-transparent bg-muted shadow-xs outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block size-5 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/apps/web/src/lib/forkfolio-api.ts
+++ b/apps/web/src/lib/forkfolio-api.ts
@@ -90,6 +90,17 @@ function buildHeaders(init?: HeadersInit): Headers {
   return headers;
 }
 
+function buildViewerHeaders(viewerUserId?: string | null): HeadersInit | undefined {
+  const normalizedViewerUserId = viewerUserId?.trim();
+  if (!normalizedViewerUserId) {
+    return undefined;
+  }
+
+  return {
+    "X-Viewer-User-Id": normalizedViewerUserId,
+  };
+}
+
 async function readErrorPayload(response: Response): Promise<ApiErrorPayload | null> {
   try {
     return (await response.json()) as ApiErrorPayload;
@@ -128,6 +139,7 @@ export async function searchRecipes(
   query: string,
   limit = 12,
   rerank = false,
+  viewerUserId?: string | null,
 ): Promise<SearchRecipesResponse> {
   const params = new URLSearchParams({
     query: query.trim(),
@@ -137,12 +149,16 @@ export async function searchRecipes(
 
   return forkfolioFetch<SearchRecipesResponse>(
     `/recipes/search/semantic?${params.toString()}`,
+    {
+      headers: buildViewerHeaders(viewerUserId),
+    },
   );
 }
 
 export async function searchRecipesByName(
   query: string,
   limit = 10,
+  viewerUserId?: string | null,
 ): Promise<SearchRecipesResponse> {
   const params = new URLSearchParams({
     query: query.trim(),
@@ -151,22 +167,33 @@ export async function searchRecipesByName(
 
   return forkfolioFetch<SearchRecipesResponse>(
     `/recipes/search/by-name?${params.toString()}`,
+    {
+      headers: buildViewerHeaders(viewerUserId),
+    },
   );
 }
 
-export async function getRecipe(recipeId: string): Promise<GetRecipeResponse> {
-  return forkfolioFetch<GetRecipeResponse>(`/recipes/${encodeURIComponent(recipeId)}`);
+export async function getRecipe(
+  recipeId: string,
+  viewerUserId?: string | null,
+): Promise<GetRecipeResponse> {
+  return forkfolioFetch<GetRecipeResponse>(`/recipes/${encodeURIComponent(recipeId)}`, {
+    headers: buildViewerHeaders(viewerUserId),
+  });
 }
 
 export async function listRecipes(
   limit = 50,
   cursor?: string,
+  viewerUserId?: string | null,
 ): Promise<ListRecipesResponse> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (cursor?.trim()) {
     params.set("cursor", cursor.trim());
   }
-  return forkfolioFetch<ListRecipesResponse>(`/recipes/?${params.toString()}`);
+  return forkfolioFetch<ListRecipesResponse>(`/recipes/?${params.toString()}`, {
+    headers: buildViewerHeaders(viewerUserId),
+  });
 }
 
 export async function deleteRecipe(recipeId: string): Promise<DeleteRecipeResponse> {

--- a/apps/web/src/lib/forkfolio-types.ts
+++ b/apps/web/src/lib/forkfolio-types.ts
@@ -33,6 +33,8 @@ export type RecipeListItem = {
   servings: string | null;
   total_time: string | null;
   source_url: string | null;
+  is_public?: boolean;
+  created_by_user_id?: string | null;
   is_test_data?: boolean;
   created_at: string | null;
   updated_at: string | null;
@@ -61,6 +63,8 @@ export type RecipeRecord = {
   servings: string | null;
   total_time: string | null;
   source_url: string | null;
+  is_public?: boolean;
+  created_by_user_id?: string | null;
   is_test_data?: boolean;
   created_at: string | null;
   updated_at: string | null;
@@ -88,6 +92,10 @@ export type ProcessRecipeRequest = {
   source_url?: string;
   sourceUrl?: string;
   enforce_deduplication?: boolean;
+  is_public?: boolean;
+  isPublic?: boolean;
+  created_by_user_id?: string;
+  createdByUserId?: string;
   isTest?: boolean;
   is_test?: boolean;
 };

--- a/apps/web/src/lib/supabase/viewer.ts
+++ b/apps/web/src/lib/supabase/viewer.ts
@@ -1,0 +1,18 @@
+import "server-only";
+
+import { hasSupabaseAuthConfig } from "@/lib/supabase/config";
+import { createClient } from "@/lib/supabase/server";
+
+export async function getOptionalViewerUserId(): Promise<string | null> {
+  if (!hasSupabaseAuthConfig()) {
+    return null;
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) {
+    return null;
+  }
+
+  return data.user.id;
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -118,6 +118,8 @@ Request body:
 {
   "raw_input": "Chocolate Chip Cookies\n\nIngredients:\n- 2 cups flour\n- 1 cup sugar\n\nInstructions:\n1. Mix\n2. Bake",
   "enforce_deduplication": true,
+  "isPublic": true,
+  "createdByUserId": "uuid",
   "isTest": false
 }
 ```
@@ -126,6 +128,8 @@ Field notes:
 
 - `raw_input` (string, required, min length `10`)
 - `enforce_deduplication` (boolean, optional, default `true`)
+- `isPublic` (boolean, optional, default `true`; `is_public` also accepted)
+- `createdByUserId` (UUID, optional; typically set by the web app from the signed-in user)
 - `isTest` (boolean, optional, default `false`; `is_test` also accepted)
 
 Success response (created):

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -15,6 +15,10 @@ Related schema extensions:
 
 - `docs/recipe-books-schema.sql` for recipe book tables and relationships
 - `docs/supabase-auth-profile-schema.sql` for `public.profiles` and auth-user sync triggers
+- `docs/recipe-ownership-schema.sql` for recipe visibility and creator ownership
+
+If you include `created_by_user_id` in the base `recipes` table definition, create
+`public.profiles` first by running `docs/supabase-auth-profile-schema.sql`.
 
 ## Table Schemas
 
@@ -29,6 +33,8 @@ The primary table storing core recipe information and metadata.
 | `servings` | VARCHAR | NULL | Number of servings (e.g., "4 servings", "6-8 people") |
 | `total_time` | VARCHAR | NULL | Total preparation and cooking time (e.g., "30 minutes", "1 hour 15 minutes") |
 | `source_url` | VARCHAR | NULL | Optional URL where the recipe was sourced from |
+| `is_public` | BOOLEAN | DEFAULT TRUE | Whether the recipe is public or private |
+| `created_by_user_id` | UUID | NULL, FK -> `public.profiles.id` | Signed-in user that created the recipe |
 | `is_test_data` | BOOLEAN | DEFAULT FALSE | Marks records created from testing scripts |
 | `created_at` | TIMESTAMP | DEFAULT NOW() | Timestamp when the recipe was created |
 | `updated_at` | TIMESTAMP | DEFAULT NOW() | Timestamp when the recipe was last updated |
@@ -38,6 +44,7 @@ The primary table storing core recipe information and metadata.
 - Consider adding index on `created_at` for efficient ordering queries
 
 **Relationships:**
+- Many-to-one with `public.profiles` via `created_by_user_id` (`ON DELETE SET NULL`)
 - One-to-many with `recipe_ingredients` (CASCADE DELETE)
 - One-to-many with `recipe_instructions` (CASCADE DELETE)
 - One-to-many with `recipe_embeddings` (CASCADE DELETE)
@@ -177,6 +184,8 @@ CREATE TABLE IF NOT EXISTS recipes (
     servings VARCHAR,
     total_time VARCHAR,
     source_url VARCHAR,
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,
+    created_by_user_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
     is_test_data BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
@@ -187,6 +196,10 @@ CREATE INDEX IF NOT EXISTS idx_recipes_created_at ON recipes(created_at DESC);
 
 -- Create index on title for search operations
 CREATE INDEX IF NOT EXISTS idx_recipes_title ON recipes(title);
+
+-- Create indexes for ownership and visibility lookups
+CREATE INDEX IF NOT EXISTS idx_recipes_is_public ON recipes(is_public);
+CREATE INDEX IF NOT EXISTS idx_recipes_created_by_user_id ON recipes(created_by_user_id);
 ```
 
 #### 2. Create `recipe_ingredients` Table
@@ -299,6 +312,8 @@ CREATE TABLE IF NOT EXISTS recipes (
     servings VARCHAR,
     total_time VARCHAR,
     source_url VARCHAR,
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,
+    created_by_user_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
     is_test_data BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT NOW(),
     updated_at TIMESTAMP DEFAULT NOW()
@@ -306,6 +321,8 @@ CREATE TABLE IF NOT EXISTS recipes (
 
 CREATE INDEX IF NOT EXISTS idx_recipes_created_at ON recipes(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_recipes_title ON recipes(title);
+CREATE INDEX IF NOT EXISTS idx_recipes_is_public ON recipes(is_public);
+CREATE INDEX IF NOT EXISTS idx_recipes_created_by_user_id ON recipes(created_by_user_id);
 
 -- ============================================
 -- 2. Create recipe_ingredients table

--- a/docs/frontend-api-contract.md
+++ b/docs/frontend-api-contract.md
@@ -101,6 +101,7 @@ Notes:
 {
   "raw_input": "Chocolate Chip Cookies...",
   "enforce_deduplication": true,
+  "isPublic": true,
   "isTest": false
 }
 ```
@@ -118,6 +119,8 @@ Notes:
     "servings": "24 cookies",
     "total_time": "35 minutes",
     "source_url": null,
+    "is_public": true,
+    "created_by_user_id": "uuid",
     "is_test_data": false,
     "created_at": "2026-03-03T00:00:00+00:00",
     "updated_at": "2026-03-03T00:00:00+00:00"

--- a/docs/recipe-ownership-schema.sql
+++ b/docs/recipe-ownership-schema.sql
@@ -1,0 +1,39 @@
+-- Recipe ownership and visibility schema update for ForkFolio.
+-- Run this after docs/supabase-auth-profile-schema.sql so public.profiles exists.
+
+alter table public.recipes
+    add column if not exists is_public boolean;
+
+update public.recipes
+set is_public = true
+where is_public is null;
+
+alter table public.recipes
+    alter column is_public set default true;
+
+alter table public.recipes
+    alter column is_public set not null;
+
+alter table public.recipes
+    add column if not exists created_by_user_id uuid;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'recipes_created_by_user_id_fkey'
+    ) then
+        alter table public.recipes
+            add constraint recipes_created_by_user_id_fkey
+            foreign key (created_by_user_id)
+            references public.profiles (id)
+            on delete set null;
+    end if;
+end $$;
+
+create index if not exists idx_recipes_is_public
+    on public.recipes(is_public);
+
+create index if not exists idx_recipes_created_by_user_id
+    on public.recipes(created_by_user_id);


### PR DESCRIPTION
## Summary
- add recipe visibility and creator ownership fields through the backend ingestion flow
- require signed-in users for recipe creation in the web proxy and expose visibility in the add-recipe/detail UX
- document the ownership schema migration and API contract updates

## Validation
- pytest app/tests/unit/test_recipe_process_and_store_endpoint.py app/tests/unit/test_recipes_list_endpoint.py
- npm test -- src/app/api/recipes/process/route.test.ts src/app/recipes/new/page.test.tsx

## Notes
- run docs/supabase-auth-profile-schema.sql before docs/recipe-ownership-schema.sql if public.profiles is not already present
- the recipe ownership SQL migration has been applied successfully in the target database