### PR TITLE
Scope experiment threads to signed-in owners

### DIFF
--- a/app/api/v1/endpoints/experiments.py
+++ b/app/api/v1/endpoints/experiments.py
@@ -8,6 +8,7 @@ from app.api.schemas import (
     ExperimentMessageCreateRequest,
     ExperimentThreadCreateRequest,
 )
+from app.api.v1.helpers.request_auth import viewer_user_id_from_request
 from app.core.config import settings
 from app.core.dependencies import get_experiment_service
 from app.core.logging import get_logger
@@ -36,25 +37,13 @@ def _to_sse_chunk(event: str, payload: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(payload, default=str)}\n\n"
 
 
-def _viewer_user_id_from_request(request: Request) -> str | None:
-    raw_value = request.headers.get("x-viewer-user-id", "").strip()
-    if not raw_value:
-        return None
-    try:
-        return str(UUID(raw_value))
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=400, detail="Invalid X-Viewer-User-Id header"
-        ) from exc
-
-
 @router.post("/threads")
 def create_experiment_thread(
     request: Request,
     payload: ExperimentThreadCreateRequest = EXPERIMENT_BODY,
     experiment_service=experiment_service_dep,
 ) -> dict:
-    viewer_user_id = _viewer_user_id_from_request(request)
+    viewer_user_id = viewer_user_id_from_request(request)
     try:
         thread = experiment_service.create_thread(
             mode=payload.mode,
@@ -97,7 +86,7 @@ def list_experiment_threads(
     ),
     experiment_service=experiment_service_dep,
 ) -> dict:
-    viewer_user_id = _viewer_user_id_from_request(request)
+    viewer_user_id = viewer_user_id_from_request(request)
     try:
         threads = experiment_service.list_threads(
             limit=limit,
@@ -129,7 +118,7 @@ def get_experiment_thread(
     experiment_service=experiment_service_dep,
 ) -> dict:
     thread_id_str = str(thread_id)
-    viewer_user_id = _viewer_user_id_from_request(request)
+    viewer_user_id = viewer_user_id_from_request(request)
     try:
         thread = experiment_service.get_thread(
             thread_id=thread_id_str,
@@ -155,7 +144,7 @@ def create_experiment_message(
     experiment_service=experiment_service_dep,
 ) -> dict:
     thread_id_str = str(thread_id)
-    viewer_user_id = _viewer_user_id_from_request(request)
+    viewer_user_id = viewer_user_id_from_request(request)
     context_recipe_ids = (
         _to_string_ids(payload.context_recipe_ids)
         if payload.context_recipe_ids is not None
@@ -207,7 +196,7 @@ def stream_experiment_message(
     experiment_service=experiment_service_dep,
 ):
     thread_id_str = str(thread_id)
-    viewer_user_id = _viewer_user_id_from_request(request)
+    viewer_user_id = viewer_user_id_from_request(request)
     context_recipe_ids = (
         _to_string_ids(payload.context_recipe_ids)
         if payload.context_recipe_ids is not None

--- a/app/api/v1/endpoints/experiments.py
+++ b/app/api/v1/endpoints/experiments.py
@@ -1,7 +1,7 @@
 import json
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 
 from app.api.schemas import (
@@ -36,11 +36,25 @@ def _to_sse_chunk(event: str, payload: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(payload, default=str)}\n\n"
 
 
+def _viewer_user_id_from_request(request: Request) -> str | None:
+    raw_value = request.headers.get("x-viewer-user-id", "").strip()
+    if not raw_value:
+        return None
+    try:
+        return str(UUID(raw_value))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail="Invalid X-Viewer-User-Id header"
+        ) from exc
+
+
 @router.post("/threads")
 def create_experiment_thread(
+    request: Request,
     payload: ExperimentThreadCreateRequest = EXPERIMENT_BODY,
     experiment_service=experiment_service_dep,
 ) -> dict:
+    viewer_user_id = _viewer_user_id_from_request(request)
     try:
         thread = experiment_service.create_thread(
             mode=payload.mode,
@@ -48,6 +62,7 @@ def create_experiment_thread(
             context_recipe_ids=_to_string_ids(payload.context_recipe_ids),
             include_test_data=payload.include_test_data,
             is_test=payload.is_test,
+            created_by_user_id=viewer_user_id,
         )
         return {"thread": thread, "success": True}
     except ExperimentValidationError as e:
@@ -69,6 +84,7 @@ def create_experiment_thread(
 
 @router.get("/threads")
 def list_experiment_threads(
+    request: Request,
     limit: int = Query(
         default=20,
         ge=1,
@@ -81,10 +97,12 @@ def list_experiment_threads(
     ),
     experiment_service=experiment_service_dep,
 ) -> dict:
+    viewer_user_id = _viewer_user_id_from_request(request)
     try:
         threads = experiment_service.list_threads(
             limit=limit,
             include_test=include_test,
+            viewer_user_id=viewer_user_id,
         )
         return {"threads": threads, "count": len(threads), "success": True}
     except Exception as e:
@@ -96,6 +114,7 @@ def list_experiment_threads(
 
 @router.get("/threads/{thread_id}")
 def get_experiment_thread(
+    request: Request,
     thread_id: UUID,
     message_limit: int = Query(
         default=120,
@@ -110,11 +129,13 @@ def get_experiment_thread(
     experiment_service=experiment_service_dep,
 ) -> dict:
     thread_id_str = str(thread_id)
+    viewer_user_id = _viewer_user_id_from_request(request)
     try:
         thread = experiment_service.get_thread(
             thread_id=thread_id_str,
             message_limit=message_limit,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         return {"thread": thread, "success": True}
     except ExperimentThreadNotFoundError as e:
@@ -128,11 +149,13 @@ def get_experiment_thread(
 
 @router.post("/threads/{thread_id}/messages")
 def create_experiment_message(
+    request: Request,
     thread_id: UUID,
     payload: ExperimentMessageCreateRequest = EXPERIMENT_BODY,
     experiment_service=experiment_service_dep,
 ) -> dict:
     thread_id_str = str(thread_id)
+    viewer_user_id = _viewer_user_id_from_request(request)
     context_recipe_ids = (
         _to_string_ids(payload.context_recipe_ids)
         if payload.context_recipe_ids is not None
@@ -152,6 +175,7 @@ def create_experiment_message(
             attach_recipe_ids=attach_recipe_ids,
             attach_recipe_names=attach_recipe_names,
             include_test_data=payload.include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         return {"thread_id": thread_id_str, **response_payload, "success": True}
     except ExperimentThreadNotFoundError as e:
@@ -177,11 +201,13 @@ def create_experiment_message(
 
 @router.post("/threads/{thread_id}/messages/stream")
 def stream_experiment_message(
+    request: Request,
     thread_id: UUID,
     payload: ExperimentMessageCreateRequest = EXPERIMENT_BODY,
     experiment_service=experiment_service_dep,
 ):
     thread_id_str = str(thread_id)
+    viewer_user_id = _viewer_user_id_from_request(request)
     context_recipe_ids = (
         _to_string_ids(payload.context_recipe_ids)
         if payload.context_recipe_ids is not None
@@ -203,6 +229,7 @@ def stream_experiment_message(
                 attach_recipe_ids=attach_recipe_ids,
                 attach_recipe_names=attach_recipe_names,
                 include_test_data=payload.include_test_data,
+                viewer_user_id=viewer_user_id,
             )
             for event_payload in event_iterator:
                 event_name = str(event_payload.get("event", "message"))

--- a/app/api/v1/helpers/request_auth.py
+++ b/app/api/v1/helpers/request_auth.py
@@ -1,0 +1,15 @@
+from uuid import UUID
+
+from fastapi import HTTPException, Request
+
+
+def viewer_user_id_from_request(request: Request) -> str | None:
+    raw_value = request.headers.get("x-viewer-user-id", "").strip()
+    if not raw_value:
+        return None
+    try:
+        return str(UUID(raw_value))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail="Invalid X-Viewer-User-Id header"
+        ) from exc

--- a/app/services/data/managers/experiment_manager.py
+++ b/app/services/data/managers/experiment_manager.py
@@ -281,7 +281,9 @@ class ExperimentManager(BaseManager):
         return isinstance(title, str) and bool(TEST_THREAD_TITLE_PATTERN.search(title))
 
     @staticmethod
-    def _owner_scope_params(viewer_user_id: str | None) -> tuple[str | None, str | None]:
+    def _owner_scope_params(
+        viewer_user_id: str | None,
+    ) -> tuple[str | None, str | None]:
         return (viewer_user_id, viewer_user_id)
 
     def _thread_exists(

--- a/app/services/data/managers/experiment_manager.py
+++ b/app/services/data/managers/experiment_manager.py
@@ -13,37 +13,57 @@ THREAD_INSERT_SQL = """
 INSERT INTO experiment_threads (
     mode,
     title,
-    metadata
+    metadata,
+    created_by_user_id
 )
-VALUES (%s, %s, %s)
+VALUES (%s, %s, %s, %s)
 RETURNING
     id,
     mode,
     title,
     metadata,
+    created_by_user_id,
     created_at,
     updated_at
+"""
+
+THREAD_OWNER_SCOPE_SQL = """
+(
+    (%s IS NULL AND t.created_by_user_id IS NULL)
+    OR t.created_by_user_id = %s
+)
 """
 
 THREAD_GET_SQL = """
 SELECT
-    id,
-    mode,
-    title,
-    metadata,
-    created_at,
-    updated_at
-FROM experiment_threads
-WHERE id = %s
-"""
+    t.id,
+    t.mode,
+    t.title,
+    t.metadata,
+    t.created_by_user_id,
+    t.created_at,
+    t.updated_at
+FROM experiment_threads t
+WHERE t.id = %s
+  AND """
+THREAD_GET_SQL += THREAD_OWNER_SCOPE_SQL
 
-THREAD_EXISTS_SQL = "SELECT 1 FROM experiment_threads WHERE id = %s"
+THREAD_EXISTS_SQL = """
+SELECT 1
+FROM experiment_threads t
+WHERE t.id = %s
+  AND """
+THREAD_EXISTS_SQL += THREAD_OWNER_SCOPE_SQL
 
 THREAD_CONTEXT_GET_SQL = """
 SELECT ecr.recipe_id
 FROM experiment_context_recipes ecr
+JOIN experiment_threads t ON t.id = ecr.thread_id
 JOIN recipes r ON r.id = ecr.recipe_id
 WHERE ecr.thread_id = %s
+  AND """
+THREAD_CONTEXT_GET_SQL += THREAD_OWNER_SCOPE_SQL
+THREAD_CONTEXT_GET_SQL += """
   AND (%s OR COALESCE(r.is_test_data, FALSE) = FALSE)
 ORDER BY ecr.added_at, ecr.recipe_id
 """
@@ -61,9 +81,11 @@ WHERE thread_id = %s
 
 MESSAGE_NEXT_SEQUENCE_SQL = """
 SELECT COALESCE(MAX(sequence_no), 0) + 1 AS next_sequence
-FROM experiment_messages
-WHERE thread_id = %s
-"""
+FROM experiment_messages em
+JOIN experiment_threads t ON t.id = em.thread_id
+WHERE em.thread_id = %s
+  AND """
+MESSAGE_NEXT_SEQUENCE_SQL += THREAD_OWNER_SCOPE_SQL
 
 MESSAGE_INSERT_SQL = """
 INSERT INTO experiment_messages (
@@ -88,17 +110,21 @@ RETURNING
 
 MESSAGES_GET_SQL = """
 SELECT
-    id,
-    thread_id,
-    sequence_no,
-    role,
-    content,
-    tool_name,
-    tool_call,
-    created_at
-FROM experiment_messages
-WHERE thread_id = %s
-ORDER BY sequence_no DESC
+    em.id,
+    em.thread_id,
+    em.sequence_no,
+    em.role,
+    em.content,
+    em.tool_name,
+    em.tool_call,
+    em.created_at
+FROM experiment_messages em
+JOIN experiment_threads t ON t.id = em.thread_id
+WHERE em.thread_id = %s
+  AND """
+MESSAGES_GET_SQL += THREAD_OWNER_SCOPE_SQL
+MESSAGES_GET_SQL += """
+ORDER BY em.sequence_no DESC
 LIMIT %s
 """
 
@@ -108,6 +134,7 @@ SELECT
     t.mode,
     t.title,
     t.metadata,
+    t.created_by_user_id,
     t.created_at,
     t.updated_at,
     m.role AS last_message_role,
@@ -121,22 +148,29 @@ LEFT JOIN LATERAL (
     ORDER BY sequence_no DESC
     LIMIT 1
 ) m ON true
+WHERE """
+THREADS_LIST_SQL += THREAD_OWNER_SCOPE_SQL
+THREADS_LIST_SQL += """
 ORDER BY t.updated_at DESC, t.created_at DESC
 LIMIT %s
 """
 
 THREAD_TITLE_UPDATE_IF_EMPTY_SQL = """
-UPDATE experiment_threads
+UPDATE experiment_threads t
 SET title = %s
-WHERE id = %s
-  AND (title IS NULL OR btrim(title) = '')
+WHERE t.id = %s
+  AND """
+THREAD_TITLE_UPDATE_IF_EMPTY_SQL += THREAD_OWNER_SCOPE_SQL
+THREAD_TITLE_UPDATE_IF_EMPTY_SQL += """
+  AND (t.title IS NULL OR btrim(t.title) = '')
 """
 
 THREAD_TOUCH_SQL = """
-UPDATE experiment_threads
+UPDATE experiment_threads t
 SET updated_at = NOW()
-WHERE id = %s
-"""
+WHERE t.id = %s
+  AND """
+THREAD_TOUCH_SQL += THREAD_OWNER_SCOPE_SQL
 
 TEST_THREAD_TITLE_PATTERN = re.compile(
     r"\b("
@@ -184,6 +218,11 @@ class ExperimentManager(BaseManager):
             "mode": row["mode"],
             "title": row["title"],
             "metadata": row.get("metadata") or {},
+            "created_by_user_id": (
+                str(row["created_by_user_id"])
+                if row.get("created_by_user_id") is not None
+                else None
+            ),
             "created_at": row["created_at"],
             "updated_at": row["updated_at"],
         }
@@ -241,8 +280,20 @@ class ExperimentManager(BaseManager):
         title = thread.get("title")
         return isinstance(title, str) and bool(TEST_THREAD_TITLE_PATTERN.search(title))
 
-    def _thread_exists(self, cursor, thread_id: str) -> bool:
-        cursor.execute(THREAD_EXISTS_SQL, (thread_id,))
+    @staticmethod
+    def _owner_scope_params(viewer_user_id: str | None) -> tuple[str | None, str | None]:
+        return (viewer_user_id, viewer_user_id)
+
+    def _thread_exists(
+        self,
+        cursor,
+        thread_id: str,
+        viewer_user_id: str | None = None,
+    ) -> bool:
+        cursor.execute(
+            THREAD_EXISTS_SQL,
+            (thread_id, *self._owner_scope_params(viewer_user_id)),
+        )
         return cursor.fetchone() is not None
 
     def _replace_context_recipes(
@@ -258,10 +309,18 @@ class ExperimentManager(BaseManager):
         self,
         thread_id: str,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[str]:
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(THREAD_CONTEXT_GET_SQL, (thread_id, include_test_data))
+                cursor.execute(
+                    THREAD_CONTEXT_GET_SQL,
+                    (
+                        thread_id,
+                        *self._owner_scope_params(viewer_user_id),
+                        include_test_data,
+                    ),
+                )
                 rows = cursor.fetchall()
                 return [str(row["recipe_id"]) for row in rows]
         except Exception as e:
@@ -273,6 +332,7 @@ class ExperimentManager(BaseManager):
         title: str | None = None,
         metadata: dict[str, Any] | None = None,
         context_recipe_ids: list[str] | None = None,
+        created_by_user_id: str | None = None,
     ) -> dict:
         normalized_context = self._normalize_context_recipe_ids(
             context_recipe_ids or []
@@ -280,7 +340,10 @@ class ExperimentManager(BaseManager):
         metadata_payload = metadata if isinstance(metadata, dict) else {}
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(THREAD_INSERT_SQL, (mode, title, Json(metadata_payload)))
+                cursor.execute(
+                    THREAD_INSERT_SQL,
+                    (mode, title, Json(metadata_payload), created_by_user_id),
+                )
                 row = cursor.fetchone()
                 if row is None:
                     raise DatabaseError("Thread insertion returned no row")
@@ -303,23 +366,41 @@ class ExperimentManager(BaseManager):
         thread_id: str,
         message_limit: int = 100,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict | None:
         query_limit = max(1, min(int(message_limit), 500))
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(THREAD_GET_SQL, (thread_id,))
+                cursor.execute(
+                    THREAD_GET_SQL,
+                    (thread_id, *self._owner_scope_params(viewer_user_id)),
+                )
                 row = cursor.fetchone()
                 if row is None:
                     return None
 
                 thread = self._serialize_thread(dict(row))
-                cursor.execute(THREAD_CONTEXT_GET_SQL, (thread_id, include_test_data))
+                cursor.execute(
+                    THREAD_CONTEXT_GET_SQL,
+                    (
+                        thread_id,
+                        *self._owner_scope_params(viewer_user_id),
+                        include_test_data,
+                    ),
+                )
                 context_rows = cursor.fetchall()
                 thread["context_recipe_ids"] = [
                     str(context_row["recipe_id"]) for context_row in context_rows
                 ]
 
-                cursor.execute(MESSAGES_GET_SQL, (thread_id, query_limit))
+                cursor.execute(
+                    MESSAGES_GET_SQL,
+                    (
+                        thread_id,
+                        *self._owner_scope_params(viewer_user_id),
+                        query_limit,
+                    ),
+                )
                 message_rows = cursor.fetchall()
                 # Query fetches latest messages first for limit efficiency.
                 messages = [
@@ -331,11 +412,14 @@ class ExperimentManager(BaseManager):
             raise DatabaseError(f"Failed to load experiment thread: {e!s}") from e
 
     def set_context_recipe_ids(
-        self, thread_id: str, context_recipe_ids: list[str]
+        self,
+        thread_id: str,
+        context_recipe_ids: list[str],
+        viewer_user_id: str | None = None,
     ) -> bool:
         try:
             with self.get_db_context() as (_conn, cursor):
-                if not self._thread_exists(cursor, thread_id):
+                if not self._thread_exists(cursor, thread_id, viewer_user_id):
                     return False
                 self._replace_context_recipes(cursor, thread_id, context_recipe_ids)
                 return True
@@ -344,11 +428,23 @@ class ExperimentManager(BaseManager):
                 f"Failed to update thread context recipes: {e!s}"
             ) from e
 
-    def list_messages(self, thread_id: str, limit: int = 100) -> list[dict]:
+    def list_messages(
+        self,
+        thread_id: str,
+        limit: int = 100,
+        viewer_user_id: str | None = None,
+    ) -> list[dict]:
         query_limit = max(1, min(int(limit), 500))
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(MESSAGES_GET_SQL, (thread_id, query_limit))
+                cursor.execute(
+                    MESSAGES_GET_SQL,
+                    (
+                        thread_id,
+                        *self._owner_scope_params(viewer_user_id),
+                        query_limit,
+                    ),
+                )
                 rows = cursor.fetchall()
                 messages = [self._serialize_message(dict(item)) for item in rows]
                 return list(reversed(messages))
@@ -362,6 +458,7 @@ class ExperimentManager(BaseManager):
         content: str,
         tool_name: str | None = None,
         tool_call: dict[str, Any] | None = None,
+        viewer_user_id: str | None = None,
     ) -> dict | None:
         normalized_content = content.strip()
         if not normalized_content:
@@ -369,10 +466,13 @@ class ExperimentManager(BaseManager):
 
         try:
             with self.get_db_context() as (_conn, cursor):
-                if not self._thread_exists(cursor, thread_id):
+                if not self._thread_exists(cursor, thread_id, viewer_user_id):
                     return None
 
-                cursor.execute(MESSAGE_NEXT_SEQUENCE_SQL, (thread_id,))
+                cursor.execute(
+                    MESSAGE_NEXT_SEQUENCE_SQL,
+                    (thread_id, *self._owner_scope_params(viewer_user_id)),
+                )
                 sequence_row = cursor.fetchone()
                 if not sequence_row:
                     raise DatabaseError("Unable to compute next message sequence")
@@ -395,12 +495,20 @@ class ExperimentManager(BaseManager):
                 row = cursor.fetchone()
                 if row is None:
                     raise DatabaseError("Message insertion returned no row")
-                cursor.execute(THREAD_TOUCH_SQL, (thread_id,))
+                cursor.execute(
+                    THREAD_TOUCH_SQL,
+                    (thread_id, *self._owner_scope_params(viewer_user_id)),
+                )
                 return self._serialize_message(dict(row))
         except Exception as e:
             raise DatabaseError(f"Failed to create experiment message: {e!s}") from e
 
-    def set_thread_title_if_empty(self, thread_id: str, title: str) -> bool:
+    def set_thread_title_if_empty(
+        self,
+        thread_id: str,
+        title: str,
+        viewer_user_id: str | None = None,
+    ) -> bool:
         normalized_title = title.strip()
         if not normalized_title:
             return False
@@ -408,18 +516,30 @@ class ExperimentManager(BaseManager):
             with self.get_db_context() as (_conn, cursor):
                 cursor.execute(
                     THREAD_TITLE_UPDATE_IF_EMPTY_SQL,
-                    (normalized_title, thread_id),
+                    (
+                        normalized_title,
+                        thread_id,
+                        *self._owner_scope_params(viewer_user_id),
+                    ),
                 )
                 return cursor.rowcount > 0
         except Exception as e:
             raise DatabaseError(f"Failed to update thread title: {e!s}") from e
 
-    def list_threads(self, limit: int = 20, include_test: bool = False) -> list[dict]:
+    def list_threads(
+        self,
+        limit: int = 20,
+        include_test: bool = False,
+        viewer_user_id: str | None = None,
+    ) -> list[dict]:
         query_limit = max(1, min(int(limit), 100))
         fetch_limit = query_limit if include_test else 500
         try:
             with self.get_db_context() as (_conn, cursor):
-                cursor.execute(THREADS_LIST_SQL, (fetch_limit,))
+                cursor.execute(
+                    THREADS_LIST_SQL,
+                    (*self._owner_scope_params(viewer_user_id), fetch_limit),
+                )
                 rows = cursor.fetchall()
                 threads: list[dict] = []
                 for row in rows:

--- a/app/services/experiment_service.py
+++ b/app/services/experiment_service.py
@@ -97,6 +97,7 @@ class ExperimentService:
         self,
         recipe_ids: list[str],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[str]:
         normalized_ids = self._normalize_context_recipe_ids(recipe_ids)
         if not normalized_ids:
@@ -107,6 +108,7 @@ class ExperimentService:
             if not self.recipe_manager.get_full_recipe(
                 recipe_id,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             ):
                 missing_ids.append(recipe_id)
 
@@ -124,6 +126,7 @@ class ExperimentService:
         context_recipe_ids: list[str] | None = None,
         include_test_data: bool = False,
         is_test: bool = False,
+        created_by_user_id: str | None = None,
     ) -> dict:
         normalized_mode = self._normalize_mode(mode)
         normalized_title = (
@@ -132,6 +135,7 @@ class ExperimentService:
         validated_context_ids = self._validate_recipe_ids(
             context_recipe_ids or [],
             include_test_data=include_test_data,
+            viewer_user_id=created_by_user_id,
         )
         metadata: dict[str, object] = {"orchestration": "langgraph-ready"}
         if is_test:
@@ -142,18 +146,26 @@ class ExperimentService:
             title=normalized_title,
             metadata=metadata,
             context_recipe_ids=validated_context_ids,
+            created_by_user_id=created_by_user_id,
         )
 
-    def list_threads(self, limit: int = 20, include_test: bool = False) -> list[dict]:
+    def list_threads(
+        self,
+        limit: int = 20,
+        include_test: bool = False,
+        viewer_user_id: str | None = None,
+    ) -> list[dict]:
         return self.experiment_manager.list_threads(
             limit=limit,
             include_test=include_test,
+            viewer_user_id=viewer_user_id,
         )
 
     def _resolve_attach_recipe_names(
         self,
         recipe_names: list[str],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> tuple[list[dict], list[str]]:
         attached_recipes: list[dict] = []
         unresolved_names: list[str] = []
@@ -163,6 +175,7 @@ class ExperimentService:
                 recipe_name,
                 limit=1,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
             if not matches:
                 unresolved_names.append(recipe_name)
@@ -174,6 +187,7 @@ class ExperimentService:
         self,
         recipe_ids: list[str],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> tuple[list[dict], list[str]]:
         attached_recipes: list[dict] = []
         unresolved_ids: list[str] = []
@@ -182,6 +196,7 @@ class ExperimentService:
             recipe = self.recipe_manager.get_full_recipe(
                 recipe_id,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
             if not recipe:
                 unresolved_ids.append(recipe_id)
@@ -200,15 +215,18 @@ class ExperimentService:
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> tuple[list[dict], list[str]]:
         if attach_recipe_ids:
             return self._resolve_attach_recipe_ids(
                 attach_recipe_ids,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
         return self._resolve_attach_recipe_names(
             attach_recipe_names or [],
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
 
     def get_thread(
@@ -216,11 +234,13 @@ class ExperimentService:
         thread_id: str,
         message_limit: int = 100,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict:
         thread = self.experiment_manager.get_thread(
             thread_id=thread_id,
             message_limit=message_limit,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         if not thread:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -230,12 +250,14 @@ class ExperimentService:
         self,
         context_recipe_ids: list[str],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[dict]:
         context_payload: list[dict] = []
         for recipe_id in context_recipe_ids:
             recipe = self.recipe_manager.get_full_recipe(
                 recipe_id,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
             if not recipe:
                 continue
@@ -274,10 +296,12 @@ class ExperimentService:
         prior_messages: list[dict],
         stream_requested: bool,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict:
         context_payload = self._build_context_payload(
             context_recipe_ids,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         history_payload = self._build_history_payload(prior_messages)
         return self._agent_graph.execute(
@@ -323,6 +347,7 @@ class ExperimentService:
         context_recipe_ids: list[str],
         prior_messages: list[dict],
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> str:
         plan = self._build_agent_plan(
             mode=mode,
@@ -331,6 +356,7 @@ class ExperimentService:
             prior_messages=prior_messages,
             stream_requested=False,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         assistant_content = str(plan.get("assistant_content") or "").strip()
         if assistant_content:
@@ -345,6 +371,7 @@ class ExperimentService:
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict:
         normalized_content = content.strip()
         if not normalized_content:
@@ -354,6 +381,7 @@ class ExperimentService:
             thread_id,
             message_limit=40,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         if not thread:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -362,10 +390,12 @@ class ExperimentService:
             validated_context_ids = self._validate_recipe_ids(
                 context_recipe_ids,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
             self.experiment_manager.set_context_recipe_ids(
                 thread_id=thread_id,
                 context_recipe_ids=validated_context_ids,
+                viewer_user_id=viewer_user_id,
             )
             thread["context_recipe_ids"] = validated_context_ids
 
@@ -373,6 +403,7 @@ class ExperimentService:
             attach_recipe_ids=attach_recipe_ids,
             attach_recipe_names=attach_recipe_names,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         attachment_message = None
         if attached_recipes:
@@ -386,6 +417,7 @@ class ExperimentService:
             self.experiment_manager.set_context_recipe_ids(
                 thread_id=thread_id,
                 context_recipe_ids=combined_context_ids,
+                viewer_user_id=viewer_user_id,
             )
             thread["context_recipe_ids"] = combined_context_ids
 
@@ -398,12 +430,14 @@ class ExperimentService:
                 thread_id=thread_id,
                 role="system",
                 content=attachment_event_text,
+                viewer_user_id=viewer_user_id,
             )
 
         user_message = self.experiment_manager.create_message(
             thread_id=thread_id,
             role="user",
             content=normalized_content,
+            viewer_user_id=viewer_user_id,
         )
         if not user_message:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -411,14 +445,18 @@ class ExperimentService:
         self.experiment_manager.set_thread_title_if_empty(
             thread_id=thread_id,
             title=normalized_content[:80],
+            viewer_user_id=viewer_user_id,
         )
 
         thread_messages = self.experiment_manager.list_messages(
-            thread_id=thread_id, limit=40
+            thread_id=thread_id,
+            limit=40,
+            viewer_user_id=viewer_user_id,
         )
         thread_context_recipe_ids = self.experiment_manager.get_context_recipe_ids(
             thread_id,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         assistant_content = self._run_agent_turn(
             mode=thread["mode"],
@@ -426,12 +464,14 @@ class ExperimentService:
             context_recipe_ids=thread_context_recipe_ids,
             prior_messages=thread_messages,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
 
         assistant_message = self.experiment_manager.create_message(
             thread_id=thread_id,
             role="assistant",
             content=assistant_content,
+            viewer_user_id=viewer_user_id,
         )
         if not assistant_message:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -440,6 +480,7 @@ class ExperimentService:
             thread_id=thread_id,
             message_limit=120,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         return {
             "thread": updated_thread,
@@ -458,6 +499,7 @@ class ExperimentService:
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> Iterator[dict]:
         normalized_content = content.strip()
         if not normalized_content:
@@ -467,6 +509,7 @@ class ExperimentService:
             thread_id,
             message_limit=40,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         if not thread:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -475,10 +518,12 @@ class ExperimentService:
             validated_context_ids = self._validate_recipe_ids(
                 context_recipe_ids,
                 include_test_data=include_test_data,
+                viewer_user_id=viewer_user_id,
             )
             self.experiment_manager.set_context_recipe_ids(
                 thread_id=thread_id,
                 context_recipe_ids=validated_context_ids,
+                viewer_user_id=viewer_user_id,
             )
             thread["context_recipe_ids"] = validated_context_ids
 
@@ -486,6 +531,7 @@ class ExperimentService:
             attach_recipe_ids=attach_recipe_ids,
             attach_recipe_names=attach_recipe_names,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         attachment_message = None
         if attached_recipes:
@@ -499,6 +545,7 @@ class ExperimentService:
             self.experiment_manager.set_context_recipe_ids(
                 thread_id=thread_id,
                 context_recipe_ids=combined_context_ids,
+                viewer_user_id=viewer_user_id,
             )
             thread["context_recipe_ids"] = combined_context_ids
 
@@ -511,6 +558,7 @@ class ExperimentService:
                 thread_id=thread_id,
                 role="system",
                 content=attachment_event_text,
+                viewer_user_id=viewer_user_id,
             )
             if attachment_message:
                 yield {
@@ -526,6 +574,7 @@ class ExperimentService:
             thread_id=thread_id,
             role="user",
             content=normalized_content,
+            viewer_user_id=viewer_user_id,
         )
         if not user_message:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -533,16 +582,20 @@ class ExperimentService:
         self.experiment_manager.set_thread_title_if_empty(
             thread_id=thread_id,
             title=normalized_content[:80],
+            viewer_user_id=viewer_user_id,
         )
 
         yield {"event": "status", "data": {"step": "drafting"}}
 
         thread_messages = self.experiment_manager.list_messages(
-            thread_id=thread_id, limit=40
+            thread_id=thread_id,
+            limit=40,
+            viewer_user_id=viewer_user_id,
         )
         thread_context_recipe_ids = self.experiment_manager.get_context_recipe_ids(
             thread_id,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         plan = self._build_agent_plan(
             mode=thread["mode"],
@@ -551,6 +604,7 @@ class ExperimentService:
             prior_messages=thread_messages,
             stream_requested=True,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
 
         assistant_parts: list[str] = []
@@ -585,6 +639,7 @@ class ExperimentService:
                         context_recipe_ids=thread_context_recipe_ids,
                         prior_messages=thread_messages,
                         include_test_data=include_test_data,
+                        viewer_user_id=viewer_user_id,
                     )
                     for fallback_chunk in self._chunk_text(fallback):
                         assistant_parts.append(fallback_chunk)
@@ -599,6 +654,7 @@ class ExperimentService:
             thread_id=thread_id,
             role="assistant",
             content=assistant_content,
+            viewer_user_id=viewer_user_id,
         )
         if not assistant_message:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
@@ -607,6 +663,7 @@ class ExperimentService:
             thread_id=thread_id,
             message_limit=120,
             include_test_data=include_test_data,
+            viewer_user_id=viewer_user_id,
         )
         yield {
             "event": "final",

--- a/app/tests/unit/test_experiment_service_guardrails.py
+++ b/app/tests/unit/test_experiment_service_guardrails.py
@@ -7,8 +7,13 @@ from app.services.experiment_service import ExperimentService
 
 
 class FakeRecipeManager:
-    def get_full_recipe(self, recipe_id: str, include_test_data: bool = False):
-        del recipe_id, include_test_data
+    def get_full_recipe(
+        self,
+        recipe_id: str,
+        include_test_data: bool = False,
+        viewer_user_id: str | None = None,
+    ):
+        del recipe_id, include_test_data, viewer_user_id
         return None
 
     def find_recipes_by_title_query(
@@ -16,8 +21,9 @@ class FakeRecipeManager:
         query: str,
         limit: int = 1,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ):
-        del query, limit, include_test_data
+        del query, limit, include_test_data, viewer_user_id
         return []
 
 
@@ -29,6 +35,7 @@ class FakeExperimentManager:
             "mode": "invent_new",
             "title": None,
             "metadata": {"orchestration": "langgraph-ready"},
+            "created_by_user_id": None,
             "context_recipe_ids": [],
             "messages": [],
             "created_at": now,
@@ -42,8 +49,9 @@ class FakeExperimentManager:
         thread_id: str,
         message_limit: int = 100,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict | None:
-        del include_test_data
+        del include_test_data, viewer_user_id
         if thread_id != self.thread["id"]:
             return None
         payload = dict(self.thread)
@@ -52,8 +60,12 @@ class FakeExperimentManager:
         return payload
 
     def set_context_recipe_ids(
-        self, thread_id: str, context_recipe_ids: list[str]
+        self,
+        thread_id: str,
+        context_recipe_ids: list[str],
+        viewer_user_id: str | None = None,
     ) -> None:
+        del viewer_user_id
         if thread_id == self.thread["id"]:
             self.thread["context_recipe_ids"] = list(context_recipe_ids)
 
@@ -64,8 +76,9 @@ class FakeExperimentManager:
         content: str,
         tool_name=None,
         tool_call=None,
+        viewer_user_id: str | None = None,
     ) -> dict | None:
-        del tool_name, tool_call
+        del tool_name, tool_call, viewer_user_id
         if thread_id != self.thread["id"]:
             return None
         self._sequence += 1
@@ -82,14 +95,26 @@ class FakeExperimentManager:
         self.messages.append(message)
         return message
 
-    def set_thread_title_if_empty(self, thread_id: str, title: str) -> bool:
+    def set_thread_title_if_empty(
+        self,
+        thread_id: str,
+        title: str,
+        viewer_user_id: str | None = None,
+    ) -> bool:
+        del viewer_user_id
         if thread_id != self.thread["id"]:
             return False
         if not self.thread["title"]:
             self.thread["title"] = title
         return True
 
-    def list_messages(self, thread_id: str, limit: int = 100) -> list[dict]:
+    def list_messages(
+        self,
+        thread_id: str,
+        limit: int = 100,
+        viewer_user_id: str | None = None,
+    ) -> list[dict]:
+        del viewer_user_id
         if thread_id != self.thread["id"]:
             return []
         return list(self.messages[-max(1, limit) :])
@@ -98,15 +123,20 @@ class FakeExperimentManager:
         self,
         thread_id: str,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> list[str]:
-        del include_test_data
+        del include_test_data, viewer_user_id
         if thread_id != self.thread["id"]:
             return []
         return list(self.thread["context_recipe_ids"])
 
-    def list_threads(self, limit: int = 20, include_test: bool = False) -> list[dict]:
-        del include_test
-        del limit
+    def list_threads(
+        self,
+        limit: int = 20,
+        include_test: bool = False,
+        viewer_user_id: str | None = None,
+    ) -> list[dict]:
+        del include_test, limit, viewer_user_id
         return [dict(self.thread)]
 
 

--- a/app/tests/unit/test_experiments_endpoints.py
+++ b/app/tests/unit/test_experiments_endpoints.py
@@ -14,12 +14,19 @@ MESSAGE_ID = "33333333-3333-3333-3333-333333333333"
 
 
 class StubExperimentService:
-    def list_threads(self, limit: int = 20, include_test: bool = False) -> list[dict]:
+    def list_threads(
+        self,
+        limit: int = 20,
+        include_test: bool = False,
+        viewer_user_id: str | None = None,
+    ) -> list[dict]:
+        del viewer_user_id
         test_thread = {
             "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             "mode": "invent_new",
             "title": "Experiment E2E seed",
             "metadata": {"orchestration": "langgraph-ready", "is_test": True},
+            "created_by_user_id": None,
             "created_at": "2026-03-16T00:00:00+00:00",
             "updated_at": "2026-03-16T00:01:00+00:00",
             "last_message_role": "assistant",
@@ -32,6 +39,7 @@ class StubExperimentService:
                 "mode": "modify_existing",
                 "title": "Veganize tikka masala",
                 "metadata": {"orchestration": "langgraph-ready"},
+                "created_by_user_id": None,
                 "created_at": "2026-03-16T00:00:00+00:00",
                 "updated_at": "2026-03-16T00:01:00+00:00",
                 "last_message_role": "assistant",
@@ -48,6 +56,7 @@ class StubExperimentService:
         context_recipe_ids: list[str] | None = None,
         include_test_data: bool = False,
         is_test: bool = False,
+        created_by_user_id: str | None = None,
     ) -> dict:
         del include_test_data
         if context_recipe_ids and RECIPE_ID not in context_recipe_ids:
@@ -63,6 +72,7 @@ class StubExperimentService:
                 "orchestration": "langgraph-ready",
                 **({"is_test": True} if is_test else {}),
             },
+            "created_by_user_id": created_by_user_id,
             "context_recipe_ids": context_recipe_ids or [],
             "messages": [],
             "created_at": "2026-03-16T00:00:00+00:00",
@@ -74,8 +84,10 @@ class StubExperimentService:
         thread_id: str,
         message_limit: int = 100,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict:
         del include_test_data
+        del viewer_user_id
         if thread_id != THREAD_ID:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         return {
@@ -83,6 +95,7 @@ class StubExperimentService:
             "mode": "modify_existing",
             "title": "Veganize tikka masala",
             "metadata": {"orchestration": "langgraph-ready"},
+            "created_by_user_id": None,
             "context_recipe_ids": [RECIPE_ID],
             "messages": [
                 {
@@ -108,8 +121,10 @@ class StubExperimentService:
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ) -> dict:
         del include_test_data
+        del viewer_user_id
         if thread_id != THREAD_ID:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         if context_recipe_ids and RECIPE_ID not in context_recipe_ids:
@@ -156,8 +171,10 @@ class StubExperimentService:
         attach_recipe_ids: list[str] | None = None,
         attach_recipe_names: list[str] | None = None,
         include_test_data: bool = False,
+        viewer_user_id: str | None = None,
     ):
         del include_test_data
+        del viewer_user_id
         if thread_id != THREAD_ID:
             raise ExperimentThreadNotFoundError("Experiment thread not found")
         yield {"event": "status", "data": {"step": "drafting"}}
@@ -232,6 +249,19 @@ def test_create_experiment_thread_missing_context_recipe_returns_404() -> None:
     detail = response.json()["detail"]
     assert detail["message"] == "One or more context recipes were not found."
     assert detail["missing_recipe_ids"] == [THREAD_ID]
+
+
+def test_create_experiment_thread_rejects_invalid_viewer_header() -> None:
+    client = TestClient(build_experiments_app())
+
+    response = client.post(
+        "/api/v1/experiments/threads",
+        headers={"X-Viewer-User-Id": "not-a-uuid"},
+        json={"mode": "invent_new"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid X-Viewer-User-Id header"
 
 
 def test_get_experiment_thread_success() -> None:

--- a/apps/web/src/app/api/experiments/threads/[threadId]/messages/route.test.ts
+++ b/apps/web/src/app/api/experiments/threads/[threadId]/messages/route.test.ts
@@ -3,14 +3,23 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createExperimentMessageMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
+const {
+  createExperimentMessageMock,
+  isForkfolioApiErrorMock,
+  getRequiredViewerUserIdMock,
+} = vi.hoisted(() => ({
   createExperimentMessageMock: vi.fn(),
   isForkfolioApiErrorMock: vi.fn(),
+  getRequiredViewerUserIdMock: vi.fn(),
 }));
 
 vi.mock("@/lib/forkfolio-api", () => ({
   createExperimentMessage: createExperimentMessageMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getRequiredViewerUserId: getRequiredViewerUserIdMock,
 }));
 
 import { POST } from "./route";
@@ -19,7 +28,9 @@ describe("POST /api/experiments/threads/[threadId]/messages", () => {
   beforeEach(() => {
     createExperimentMessageMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    getRequiredViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getRequiredViewerUserIdMock.mockResolvedValue({ viewerUserId: "user-123" });
   });
 
   it("returns 400 when content is missing", async () => {
@@ -184,7 +195,7 @@ describe("POST /api/experiments/threads/[threadId]/messages", () => {
       content: "Make this vegan",
       context_recipe_ids: ["recipe-1"],
       attach_recipe_ids: ["recipe-1"],
-    });
+    }, "user-123");
   });
 
   it("maps Forkfolio API errors", async () => {
@@ -213,5 +224,34 @@ describe("POST /api/experiments/threads/[threadId]/messages", () => {
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ detail: "Experiment thread not found" });
+  });
+
+  it("returns 401 when the user is not signed in", async () => {
+    getRequiredViewerUserIdMock.mockResolvedValue({
+      viewerUserId: null,
+      detail: "Sign in to use experiment threads.",
+      status: 401,
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/experiments/threads/thread-1/messages",
+      {
+        method: "POST",
+        body: JSON.stringify({ content: "hello" }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ threadId: "thread-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      detail: "Sign in to use experiment threads.",
+    });
+    expect(createExperimentMessageMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/experiments/threads/[threadId]/messages/route.ts
+++ b/apps/web/src/app/api/experiments/threads/[threadId]/messages/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { createExperimentMessage, isForkfolioApiError } from "@/lib/forkfolio-api";
+import { getRequiredViewerUserId } from "@/lib/supabase/viewer";
 import type { CreateExperimentMessageRequest } from "@/lib/forkfolio-types";
 
 type ThreadMessageRoutePayload = {
@@ -113,10 +114,22 @@ export async function POST(
     );
   }
 
+  const viewerResult = await getRequiredViewerUserId(
+    "Experiment threads",
+    "Sign in to use experiment threads.",
+  );
+  if (!viewerResult.viewerUserId) {
+    return NextResponse.json(
+      { detail: viewerResult.detail },
+      { status: viewerResult.status },
+    );
+  }
+
   try {
     const response = await createExperimentMessage(
       normalizedThreadId,
       normalizedPayload.payload,
+      viewerResult.viewerUserId,
     );
     return NextResponse.json(response, {
       status: 200,

--- a/apps/web/src/app/api/experiments/threads/[threadId]/messages/stream/route.test.ts
+++ b/apps/web/src/app/api/experiments/threads/[threadId]/messages/stream/route.test.ts
@@ -3,6 +3,14 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { getRequiredViewerUserIdMock } = vi.hoisted(() => ({
+  getRequiredViewerUserIdMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getRequiredViewerUserId: getRequiredViewerUserIdMock,
+}));
+
 import { POST } from "./route";
 
 function createSseResponse(events: string, status = 200): Response {
@@ -22,6 +30,8 @@ function createSseResponse(events: string, status = 200): Response {
 describe("POST /api/experiments/threads/[threadId]/messages/stream", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", vi.fn());
+    getRequiredViewerUserIdMock.mockReset();
+    getRequiredViewerUserIdMock.mockResolvedValue({ viewerUserId: "user-123" });
   });
 
   it("returns 400 when content is missing", async () => {
@@ -100,6 +110,9 @@ describe("POST /api/experiments/threads/[threadId]/messages/stream", () => {
       expect.stringContaining("/experiments/threads/thread-1/messages/stream"),
       expect.objectContaining({ method: "POST" }),
     );
+    const upstreamHeaders = fetchMock.mock.calls[0]?.[1]?.headers;
+    expect(upstreamHeaders).toBeInstanceOf(Headers);
+    expect((upstreamHeaders as Headers).get("X-Viewer-User-Id")).toBe("user-123");
     expect(await response.text()).toContain("event: status");
   });
 
@@ -130,5 +143,34 @@ describe("POST /api/experiments/threads/[threadId]/messages/stream", () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ detail: "Thread not found" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 401 when the user is not signed in", async () => {
+    getRequiredViewerUserIdMock.mockResolvedValue({
+      viewerUserId: null,
+      detail: "Sign in to use experiment threads.",
+      status: 401,
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/experiments/threads/thread-1/messages/stream",
+      {
+        method: "POST",
+        body: JSON.stringify({ content: "Make this vegan" }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ threadId: "thread-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      detail: "Sign in to use experiment threads.",
+    });
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/experiments/threads/[threadId]/messages/stream/route.ts
+++ b/apps/web/src/app/api/experiments/threads/[threadId]/messages/stream/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getRequiredViewerUserId } from "@/lib/supabase/viewer";
+
 const DEFAULT_API_BASE_URL = "https://forkfolio-be.onrender.com";
 const DEFAULT_API_BASE_PATH = "/api/v1";
 
@@ -119,10 +121,11 @@ async function readErrorDetail(response: Response): Promise<string | null> {
   }
 }
 
-function buildUpstreamHeaders(): Headers {
+function buildUpstreamHeaders(viewerUserId: string): Headers {
   const headers = new Headers({
     Accept: "text/event-stream",
     "Content-Type": "application/json",
+    "X-Viewer-User-Id": viewerUserId,
   });
   if (API_TOKEN) {
     headers.set("X-API-Token", API_TOKEN);
@@ -159,13 +162,24 @@ export async function POST(
     );
   }
 
+  const viewerResult = await getRequiredViewerUserId(
+    "Experiment threads",
+    "Sign in to use experiment threads.",
+  );
+  if (!viewerResult.viewerUserId) {
+    return NextResponse.json(
+      { detail: viewerResult.detail },
+      { status: viewerResult.status },
+    );
+  }
+
   const upstreamUrl = `${API_BASE_URL}${API_BASE_PATH}/experiments/threads/${encodeURIComponent(
     normalizedThreadId,
   )}/messages/stream`;
 
   const upstreamResponse = await fetch(upstreamUrl, {
     method: "POST",
-    headers: buildUpstreamHeaders(),
+    headers: buildUpstreamHeaders(viewerResult.viewerUserId),
     body: JSON.stringify(normalizedPayload.payload),
     cache: "no-store",
   });

--- a/apps/web/src/app/api/experiments/threads/[threadId]/route.test.ts
+++ b/apps/web/src/app/api/experiments/threads/[threadId]/route.test.ts
@@ -3,14 +3,20 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getExperimentThreadMock, isForkfolioApiErrorMock } = vi.hoisted(() => ({
-  getExperimentThreadMock: vi.fn(),
-  isForkfolioApiErrorMock: vi.fn(),
-}));
+const { getExperimentThreadMock, isForkfolioApiErrorMock, getRequiredViewerUserIdMock } =
+  vi.hoisted(() => ({
+    getExperimentThreadMock: vi.fn(),
+    isForkfolioApiErrorMock: vi.fn(),
+    getRequiredViewerUserIdMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/forkfolio-api", () => ({
   getExperimentThread: getExperimentThreadMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getRequiredViewerUserId: getRequiredViewerUserIdMock,
 }));
 
 import { GET } from "./route";
@@ -19,7 +25,9 @@ describe("GET /api/experiments/threads/[threadId]", () => {
   beforeEach(() => {
     getExperimentThreadMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
+    getRequiredViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getRequiredViewerUserIdMock.mockResolvedValue({ viewerUserId: "user-123" });
   });
 
   it("returns 400 when thread id is blank", async () => {
@@ -58,7 +66,7 @@ describe("GET /api/experiments/threads/[threadId]", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(getExperimentThreadMock).toHaveBeenCalledWith("thread-1", 200);
+    expect(getExperimentThreadMock).toHaveBeenCalledWith("thread-1", 200, "user-123");
   });
 
   it("maps Forkfolio API errors", async () => {
@@ -77,5 +85,24 @@ describe("GET /api/experiments/threads/[threadId]", () => {
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ detail: "Experiment thread not found" });
+  });
+
+  it("returns 401 when the user is not signed in", async () => {
+    getRequiredViewerUserIdMock.mockResolvedValue({
+      viewerUserId: null,
+      detail: "Sign in to use experiment threads.",
+      status: 401,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/experiments/threads/thread-1");
+    const response = await GET(request, {
+      params: Promise.resolve({ threadId: "thread-1" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      detail: "Sign in to use experiment threads.",
+    });
+    expect(getExperimentThreadMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/experiments/threads/[threadId]/route.ts
+++ b/apps/web/src/app/api/experiments/threads/[threadId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { getExperimentThread, isForkfolioApiError } from "@/lib/forkfolio-api";
+import { getRequiredViewerUserId } from "@/lib/supabase/viewer";
 
 const DEFAULT_MESSAGE_LIMIT = 120;
 
@@ -27,9 +28,23 @@ export async function GET(
   }
 
   const messageLimit = parseMessageLimit(request.nextUrl.searchParams.get("message_limit"));
+  const viewerResult = await getRequiredViewerUserId(
+    "Experiment threads",
+    "Sign in to use experiment threads.",
+  );
+  if (!viewerResult.viewerUserId) {
+    return NextResponse.json(
+      { detail: viewerResult.detail },
+      { status: viewerResult.status },
+    );
+  }
 
   try {
-    const response = await getExperimentThread(normalizedThreadId, messageLimit);
+    const response = await getExperimentThread(
+      normalizedThreadId,
+      messageLimit,
+      viewerResult.viewerUserId,
+    );
     return NextResponse.json(response, {
       status: 200,
       headers: {

--- a/apps/web/src/app/api/experiments/threads/route.test.ts
+++ b/apps/web/src/app/api/experiments/threads/route.test.ts
@@ -3,16 +3,26 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createExperimentThreadMock, isForkfolioApiErrorMock, listExperimentThreadsMock } = vi.hoisted(() => ({
+const {
+  createExperimentThreadMock,
+  isForkfolioApiErrorMock,
+  listExperimentThreadsMock,
+  getRequiredViewerUserIdMock,
+} = vi.hoisted(() => ({
   createExperimentThreadMock: vi.fn(),
   isForkfolioApiErrorMock: vi.fn(),
   listExperimentThreadsMock: vi.fn(),
+  getRequiredViewerUserIdMock: vi.fn(),
 }));
 
 vi.mock("@/lib/forkfolio-api", () => ({
   createExperimentThread: createExperimentThreadMock,
   isForkfolioApiError: isForkfolioApiErrorMock,
   listExperimentThreads: listExperimentThreadsMock,
+}));
+
+vi.mock("@/lib/supabase/viewer", () => ({
+  getRequiredViewerUserId: getRequiredViewerUserIdMock,
 }));
 
 import { GET, POST } from "./route";
@@ -22,7 +32,9 @@ describe("POST /api/experiments/threads", () => {
     createExperimentThreadMock.mockReset();
     isForkfolioApiErrorMock.mockReset();
     listExperimentThreadsMock.mockReset();
+    getRequiredViewerUserIdMock.mockReset();
     isForkfolioApiErrorMock.mockReturnValue(false);
+    getRequiredViewerUserIdMock.mockResolvedValue({ viewerUserId: "user-123" });
   });
 
   it("returns 400 when JSON body is invalid", async () => {
@@ -96,7 +108,7 @@ describe("POST /api/experiments/threads", () => {
       title: "Vegan weeknight curry",
       context_recipe_ids: ["recipe-1", "recipe-2"],
       is_test: true,
-    });
+    }, "user-123");
   });
 
   it("returns 400 when is_test has invalid type", async () => {
@@ -142,6 +154,30 @@ describe("POST /api/experiments/threads", () => {
     expect(await response.json()).toEqual({ detail: "Recipe missing" });
   });
 
+  it("returns 401 when the user is not signed in", async () => {
+    getRequiredViewerUserIdMock.mockResolvedValue({
+      viewerUserId: null,
+      detail: "Sign in to use experiment threads.",
+      status: 401,
+    });
+
+    const request = new NextRequest("http://localhost:3000/api/experiments/threads", {
+      method: "POST",
+      body: JSON.stringify({ mode: "invent_new" }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      detail: "Sign in to use experiment threads.",
+    });
+    expect(createExperimentThreadMock).not.toHaveBeenCalled();
+  });
+
   it("lists experiment threads", async () => {
     listExperimentThreadsMock.mockResolvedValue({
       success: true,
@@ -177,7 +213,7 @@ describe("POST /api/experiments/threads", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(listExperimentThreadsMock).toHaveBeenCalledWith(10, false);
+    expect(listExperimentThreadsMock).toHaveBeenCalledWith(10, false, "user-123");
     expect(await response.json()).toMatchObject({ count: 1 });
   });
 
@@ -218,7 +254,7 @@ describe("POST /api/experiments/threads", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(listExperimentThreadsMock).toHaveBeenCalledWith(10, true);
+    expect(listExperimentThreadsMock).toHaveBeenCalledWith(10, true, "user-123");
     expect(body.count).toBe(2);
     expect(body.threads).toHaveLength(2);
   });

--- a/apps/web/src/app/api/experiments/threads/route.ts
+++ b/apps/web/src/app/api/experiments/threads/route.ts
@@ -5,6 +5,7 @@ import {
   isForkfolioApiError,
   listExperimentThreads,
 } from "@/lib/forkfolio-api";
+import { getRequiredViewerUserId } from "@/lib/supabase/viewer";
 import type {
   CreateExperimentThreadRequest,
   ExperimentMode,
@@ -204,8 +205,22 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const viewerResult = await getRequiredViewerUserId(
+    "Experiment threads",
+    "Sign in to use experiment threads.",
+  );
+  if (!viewerResult.viewerUserId) {
+    return NextResponse.json(
+      { detail: viewerResult.detail },
+      { status: viewerResult.status },
+    );
+  }
+
   try {
-    const response = await createExperimentThread(normalizedPayload.payload);
+    const response = await createExperimentThread(
+      normalizedPayload.payload,
+      viewerResult.viewerUserId,
+    );
     return NextResponse.json(response, {
       status: 200,
       headers: {
@@ -232,8 +247,22 @@ export async function GET(request: NextRequest) {
   const includeTest = parseIncludeTest(
     request.nextUrl.searchParams.get("include_test"),
   );
+  const viewerResult = await getRequiredViewerUserId(
+    "Experiment threads",
+    "Sign in to use experiment threads.",
+  );
+  if (!viewerResult.viewerUserId) {
+    return NextResponse.json(
+      { detail: viewerResult.detail },
+      { status: viewerResult.status },
+    );
+  }
   try {
-    const response = await listExperimentThreads(limit, includeTest);
+    const response = await listExperimentThreads(
+      limit,
+      includeTest,
+      viewerResult.viewerUserId,
+    );
     const listedThreads = Array.isArray(response.threads) ? response.threads : [];
     const filteredThreads = includeTest
       ? listedThreads.slice(0, limit)

--- a/apps/web/src/app/experiment/page.test.tsx
+++ b/apps/web/src/app/experiment/page.test.tsx
@@ -623,6 +623,66 @@ describe("/experiment page", () => {
     expect(reloadCalls).toHaveLength(0);
   });
 
+  it("renders a private workspace gate when history requires sign-in", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      jsonResponse({ detail: "Sign in to use experiment threads." }, 401),
+    );
+
+    render(<ExperimentPage />);
+
+    expect(await screen.findByRole("heading", { name: "Sign in to open Recipe Lab" })).toBeInTheDocument();
+    expect(screen.getByText("Private workspace")).toBeInTheDocument();
+    expect(screen.getByText("Sign in for history")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "New Thread" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Your message")).not.toBeInTheDocument();
+    expect(screen.queryByText("No conversation history yet.")).not.toBeInTheDocument();
+  });
+
+  it("renders auth setup guidance and retries when auth is unavailable", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { detail: "Experiment threads require Supabase Auth configuration." },
+        503,
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(<ExperimentPage />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Recipe Lab needs authentication setup" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Authentication unavailable")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "New Thread" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Your message")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Check again" }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/experiments/threads?limit=40",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({
+          Accept: "application/json",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/experiments/threads?limit=40",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: expect.objectContaining({
+          Accept: "application/json",
+        }),
+      }),
+    );
+  });
+
   it("stores latest assistant output before opening Add Recipe flow", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockImplementation(async (input, init) => {

--- a/apps/web/src/app/experiment/page.tsx
+++ b/apps/web/src/app/experiment/page.tsx
@@ -1,11 +1,28 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { History, Loader2, Paperclip, Plus, Send, Sparkles, X } from "lucide-react";
-import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  History,
+  Loader2,
+  LockKeyhole,
+  Paperclip,
+  Plus,
+  Send,
+  Sparkles,
+  X,
+} from "lucide-react";
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { AuthProfileButton } from "@/components/auth-profile-button";
 import { ForkfolioHeader } from "@/components/forkfolio-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -54,6 +71,8 @@ type ParsedSseEvent = {
   event: string;
   data: unknown;
 };
+
+type ExperimentAccessState = "ready" | "auth_required" | "auth_unavailable";
 
 const STARTER_PROMPTS = [
   "Invent a new weeknight dinner with at least 30g protein per serving.",
@@ -229,6 +248,49 @@ function getErrorMessage(error: unknown, fallback: string): string {
   return fallback;
 }
 
+function getAccessState(error: unknown): ExperimentAccessState | null {
+  if (!(error instanceof BrowserApiError)) {
+    return null;
+  }
+  if (error.status === 401) {
+    return "auth_required";
+  }
+  if (error.status === 503) {
+    return "auth_unavailable";
+  }
+  return null;
+}
+
+function getAccessStateCopy(accessState: ExperimentAccessState): {
+  badgeLabel: string;
+  title: string;
+  description: string;
+  sidebarTitle: string;
+  sidebarDescription: string;
+} {
+  if (accessState === "auth_required") {
+    return {
+      badgeLabel: "Private workspace",
+      title: "Sign in to open Recipe Lab",
+      description:
+        "Your experiment threads, recipe attachments, and saved context now stay tied to your account. Sign in to keep brainstorming where you left off.",
+      sidebarTitle: "Sign in for history",
+      sidebarDescription:
+        "Thread history is now private to each account, so the lab stays personal instead of shared.",
+    };
+  }
+
+  return {
+    badgeLabel: "Setup required",
+    title: "Recipe Lab needs authentication setup",
+    description:
+      "Private experiment threads depend on Supabase Auth. Add the auth configuration, then reload to unlock history and messaging.",
+    sidebarTitle: "Authentication unavailable",
+    sidebarDescription:
+      "Recipe Lab history cannot load until authentication is configured for this environment.",
+  };
+}
+
 function formatThreadLabel(thread: ExperimentThreadSummary): string {
   const base = thread.title?.trim() ? thread.title.trim() : "Untitled conversation";
   return base.length > 64 ? `${base.slice(0, 61)}...` : base;
@@ -337,6 +399,7 @@ export default function ExperimentPage() {
   const [isLoadingThread, setIsLoadingThread] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isSendingMessage, setIsSendingMessage] = useState(false);
+  const [accessState, setAccessState] = useState<ExperimentAccessState>("ready");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [attachmentFeedback, setAttachmentFeedback] = useState<string | null>(null);
   const [streamStatus, setStreamStatus] = useState<string | null>(null);
@@ -357,13 +420,32 @@ export default function ExperimentPage() {
     messageInput.trim().length > 0 &&
     !isCreatingThread &&
     !isLoadingThread;
+  const isAccessBlocked = accessState !== "ready";
+  const accessStateCopy = isAccessBlocked ? getAccessStateCopy(accessState) : null;
+
+  function applyAccessState(nextAccessState: ExperimentAccessState) {
+    setAccessState(nextAccessState);
+    setThread(null);
+    setThreadHistory([]);
+    setPendingAttachments([]);
+    setAttachmentFeedback(null);
+    setStreamStatus(null);
+    setStreamingMessageId(null);
+    setErrorMessage(null);
+  }
 
   async function refreshHistory() {
     setIsLoadingHistory(true);
     try {
       const response = await listThreadsClient(40);
+      setAccessState("ready");
       setThreadHistory(response.threads ?? []);
-    } catch {
+    } catch (error) {
+      const nextAccessState = getAccessState(error);
+      if (nextAccessState) {
+        applyAccessState(nextAccessState);
+        return;
+      }
       setThreadHistory([]);
     } finally {
       setIsLoadingHistory(false);
@@ -378,8 +460,12 @@ export default function ExperimentPage() {
     });
   }
 
-  useEffect(() => {
+  const loadInitialHistory = useEffectEvent(() => {
     void refreshHistory();
+  });
+
+  useEffect(() => {
+    loadInitialHistory();
   }, []);
 
   useEffect(() => {
@@ -444,10 +530,16 @@ export default function ExperimentPage() {
 
     try {
       const response = await createThreadClient();
+      setAccessState("ready");
       const nextThread = normalizeThread(response.thread);
       setThread(nextThread);
       await refreshHistory();
     } catch (error) {
+      const nextAccessState = getAccessState(error);
+      if (nextAccessState) {
+        applyAccessState(nextAccessState);
+        return;
+      }
       setErrorMessage(getErrorMessage(error, "Failed to start a new conversation."));
     } finally {
       setIsCreatingThread(false);
@@ -468,9 +560,15 @@ export default function ExperimentPage() {
     setIsLoadingThread(true);
     try {
       const response = await getThreadClient(normalizedThreadId);
+      setAccessState("ready");
       const nextThread = normalizeThread(response.thread);
       setThread(nextThread);
     } catch (error) {
+      const nextAccessState = getAccessState(error);
+      if (nextAccessState) {
+        applyAccessState(nextAccessState);
+        return;
+      }
       setErrorMessage(getErrorMessage(error, "Failed to load conversation."));
     } finally {
       setIsLoadingThread(false);
@@ -516,11 +614,20 @@ export default function ExperimentPage() {
       setIsCreatingThread(true);
       try {
         const createResponse = await createThreadClient();
+        setAccessState("ready");
         activeThread = normalizeThread(createResponse.thread);
         setThread(activeThread);
         upsertThreadHistory(activeThread);
         void refreshHistory();
       } catch (error) {
+        const nextAccessState = getAccessState(error);
+        if (nextAccessState) {
+          applyAccessState(nextAccessState);
+          setIsSendingMessage(false);
+          setStreamStatus(null);
+          setStreamingMessageId(null);
+          return;
+        }
         setErrorMessage(getErrorMessage(error, "Failed to start a new conversation."));
         setIsSendingMessage(false);
         setStreamStatus(null);
@@ -759,6 +866,11 @@ export default function ExperimentPage() {
       }
       upsertThreadHistory(nextThreadSummary);
     } catch (error) {
+      const nextAccessState = getAccessState(error);
+      if (nextAccessState) {
+        applyAccessState(nextAccessState);
+        return;
+      }
       setThread(previousThreadSnapshot);
       setErrorMessage(getErrorMessage(error, "Failed to send message."));
     } finally {
@@ -808,24 +920,33 @@ export default function ExperimentPage() {
             <CardHeader className="space-y-3">
               <CardTitle className="flex items-center gap-2 text-xl">
                 <History className="size-4 text-primary" />
-                History
+                {isAccessBlocked ? "Private history" : "History"}
               </CardTitle>
-              <Button onClick={() => void handleNewThread()} disabled={isCreatingThread}>
-                {isCreatingThread ? (
-                  <>
-                    <Loader2 className="size-4 animate-spin" />
-                    Starting…
-                  </>
-                ) : (
-                  <>
-                    <Plus className="size-4" />
-                    New Thread
-                  </>
-                )}
-              </Button>
+              {!isAccessBlocked ? (
+                <Button onClick={() => void handleNewThread()} disabled={isCreatingThread}>
+                  {isCreatingThread ? (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Starting…
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="size-4" />
+                      New Thread
+                    </>
+                  )}
+                </Button>
+              ) : null}
             </CardHeader>
             <CardContent className="h-[calc(82vh-8rem)] space-y-2 overflow-y-auto">
-              {isLoadingHistory ? (
+              {isAccessBlocked && accessStateCopy ? (
+                <div className="flex h-full flex-col justify-center gap-3 rounded-xl border border-dashed border-border/80 bg-muted/20 p-4">
+                  <p className="text-sm font-semibold">{accessStateCopy.sidebarTitle}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {accessStateCopy.sidebarDescription}
+                  </p>
+                </div>
+              ) : isLoadingHistory ? (
                 <p className="text-sm text-muted-foreground">Loading…</p>
               ) : threadHistory.length === 0 ? (
                 <p className="text-sm text-muted-foreground">No conversation history yet.</p>
@@ -857,12 +978,16 @@ export default function ExperimentPage() {
           <Card className="h-[82vh] overflow-hidden">
             <CardHeader>
               <CardTitle>
-                {thread
+                {isAccessBlocked && accessStateCopy
+                  ? accessStateCopy.title
+                  : thread
                   ? thread.title?.trim() || "Untitled conversation"
                   : "Start a new conversation"}
               </CardTitle>
               <CardDescription>
-                {thread
+                {isAccessBlocked && accessStateCopy
+                  ? accessStateCopy.description
+                  : thread
                   ? "Continue the thread or attach recipes before your next message."
                   : "Type a message to start instantly, or use New Thread."}
               </CardDescription>
@@ -880,7 +1005,66 @@ export default function ExperimentPage() {
               ) : null}
 
               <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-border/70 bg-muted/20">
-                {!thread ? (
+                {isAccessBlocked && accessStateCopy ? (
+                  <div className="flex h-full items-center justify-center overflow-y-auto p-4 sm:p-6">
+                    <div className="w-full max-w-2xl rounded-[1.75rem] border border-border/70 bg-background/90 p-5 shadow-sm sm:p-6">
+                      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+                        <div className="space-y-4">
+                          <span className="inline-flex size-11 items-center justify-center rounded-2xl bg-primary/12 text-primary">
+                            <LockKeyhole className="size-5" />
+                          </span>
+                          <div className="space-y-2">
+                            <p className="text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+                              {accessStateCopy.badgeLabel}
+                            </p>
+                            <h2 className="font-display text-3xl leading-tight tracking-tight sm:text-4xl">
+                              {accessStateCopy.title}
+                            </h2>
+                            <p className="max-w-[56ch] text-sm leading-relaxed text-muted-foreground sm:text-base">
+                              {accessStateCopy.description}
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <Badge variant="secondary" className="rounded-full px-3 py-1">
+                              Private history
+                            </Badge>
+                            <Badge variant="secondary" className="rounded-full px-3 py-1">
+                              Saved recipe context
+                            </Badge>
+                            <Badge variant="secondary" className="rounded-full px-3 py-1">
+                              Account-scoped drafts
+                            </Badge>
+                          </div>
+                        </div>
+
+                        <div className="flex shrink-0 flex-col items-start gap-3 lg:items-end">
+                          {accessState === "auth_required" ? (
+                            <>
+                              <AuthProfileButton />
+                              <p className="max-w-xs text-sm text-muted-foreground lg:text-right">
+                                Sign in here or from the header to continue in your personal lab.
+                              </p>
+                            </>
+                          ) : (
+                            <>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => void refreshHistory()}
+                              >
+                                Check again
+                              </Button>
+                              <p className="max-w-xs text-sm text-muted-foreground lg:text-right">
+                                Once authentication is configured, reload this view to restore
+                                thread history and messaging.
+                              </p>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : !thread ? (
                   <div className="flex h-full flex-col gap-4 overflow-y-auto p-4 sm:p-5">
                     <div className="rounded-lg border border-border/70 bg-background/90 p-4">
                       <div className="flex items-center gap-2">
@@ -985,205 +1169,211 @@ export default function ExperimentPage() {
                 )}
               </div>
 
-              <form
-                className="space-y-3 rounded-lg border border-border/70 bg-card/30 p-3"
-                onSubmit={handleSendMessage}
-              >
-                <div className="space-y-2">
-                  <Label htmlFor="message-input">Your message</Label>
-                  <Textarea
-                    id="message-input"
-                    value={messageInput}
-                    onChange={(event) => setMessageInput(event.target.value)}
-                    placeholder="Attach chicken tikka masala and make it vegan + high protein."
-                    className="min-h-24"
-                    disabled={isBusy}
-                  />
-                </div>
-
-                {pendingAttachments.length > 0 ? (
+              {!isAccessBlocked ? (
+                <form
+                  className="space-y-3 rounded-lg border border-border/70 bg-card/30 p-3"
+                  onSubmit={handleSendMessage}
+                >
                   <div className="space-y-2">
-                    <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      Attached to next message
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {pendingAttachments.map((attachment) => (
-                        <Badge
-                          key={attachment.id}
-                          variant="secondary"
-                          className="inline-flex items-center gap-1"
-                        >
-                          <span>{attachment.name}</span>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon-xs"
-                            className="opacity-80 transition-opacity hover:opacity-100"
-                            onClick={() => removePendingAttachment(attachment.id)}
-                            aria-label={`Remove ${attachment.name}`}
-                          >
-                            <X className="size-3" />
-                          </Button>
-                        </Badge>
-                      ))}
-                    </div>
+                    <Label htmlFor="message-input">Your message</Label>
+                    <Textarea
+                      id="message-input"
+                      value={messageInput}
+                      onChange={(event) => setMessageInput(event.target.value)}
+                      placeholder="Attach chicken tikka masala and make it vegan + high protein."
+                      className="min-h-24"
+                      disabled={isBusy}
+                    />
                   </div>
-                ) : null}
 
-                <div className="flex items-center justify-between gap-2">
-                  <Dialog open={isAttachDialogOpen} onOpenChange={setIsAttachDialogOpen}>
-                    <DialogTrigger asChild>
-                      <Button type="button" variant="outline" disabled={isBusy}>
-                        <Paperclip className="size-4" />
-                        Attach
-                      </Button>
-                    </DialogTrigger>
-                    <DialogContent className="max-w-xl gap-0 p-0">
-                      <DialogHeader className="border-b px-5 py-4">
-                        <DialogTitle>Attach Recipes</DialogTitle>
-                        <DialogDescription>
-                          Search by recipe name. Add one or more recipes to your next message.
-                        </DialogDescription>
-                      </DialogHeader>
+                  {pendingAttachments.length > 0 ? (
+                    <div className="space-y-2">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        Attached to next message
+                      </p>
+                      <div className="flex flex-wrap gap-2">
+                        {pendingAttachments.map((attachment) => (
+                          <Badge
+                            key={attachment.id}
+                            variant="secondary"
+                            className="inline-flex items-center gap-1"
+                          >
+                            <span>{attachment.name}</span>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className="opacity-80 transition-opacity hover:opacity-100"
+                              onClick={() => removePendingAttachment(attachment.id)}
+                              aria-label={`Remove ${attachment.name}`}
+                            >
+                              <X className="size-3" />
+                            </Button>
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
 
-                      <div className="space-y-4 px-5 py-4">
-                        <div className="space-y-2">
-                          <Label htmlFor="attach-search-input">Recipe name</Label>
-                          <Input
-                            id="attach-search-input"
-                            value={attachSearchInput}
-                            onChange={(event) => setAttachSearchInput(event.target.value)}
-                            placeholder="Search chicken tikka masala"
-                          />
-                          {normalizedAttachQuery.length > 0 && normalizedAttachQuery.length < 3 ? (
-                            <p className="text-sm text-muted-foreground">
-                              Type at least 3 characters.
-                            </p>
-                          ) : null}
-                          {isSearchingAttachments ? (
-                            <p className="text-sm text-muted-foreground">Searching…</p>
-                          ) : null}
-                          {attachSearchError ? (
-                            <p className="text-sm text-destructive">{attachSearchError}</p>
-                          ) : null}
-                        </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <Dialog open={isAttachDialogOpen} onOpenChange={setIsAttachDialogOpen}>
+                      <DialogTrigger asChild>
+                        <Button type="button" variant="outline" disabled={isBusy}>
+                          <Paperclip className="size-4" />
+                          Attach
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent className="max-w-xl gap-0 p-0">
+                        <DialogHeader className="border-b px-5 py-4">
+                          <DialogTitle>Attach Recipes</DialogTitle>
+                          <DialogDescription>
+                            Search by recipe name. Add one or more recipes to your next message.
+                          </DialogDescription>
+                        </DialogHeader>
 
-                        <div className="rounded-lg border border-border/70 bg-muted/20">
-                          <div className="max-h-64 space-y-2 overflow-y-auto p-2">
-                            {normalizedAttachQuery.length < 3 ? (
-                              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                                Search with at least 3 characters to attach a recipe.
+                        <div className="space-y-4 px-5 py-4">
+                          <div className="space-y-2">
+                            <Label htmlFor="attach-search-input">Recipe name</Label>
+                            <Input
+                              id="attach-search-input"
+                              value={attachSearchInput}
+                              onChange={(event) => setAttachSearchInput(event.target.value)}
+                              placeholder="Search chicken tikka masala"
+                            />
+                            {normalizedAttachQuery.length > 0 && normalizedAttachQuery.length < 3 ? (
+                              <p className="text-sm text-muted-foreground">
+                                Type at least 3 characters.
                               </p>
                             ) : null}
-                            {normalizedAttachQuery.length >= 3 &&
-                            !isSearchingAttachments &&
-                            attachSearchResults.length === 0 &&
-                            !attachSearchError ? (
-                              <p className="px-2 py-6 text-center text-sm text-muted-foreground">
-                                No recipes found for &quot;{normalizedAttachQuery}&quot;.
-                              </p>
+                            {isSearchingAttachments ? (
+                              <p className="text-sm text-muted-foreground">Searching…</p>
                             ) : null}
-                            {attachSearchResults.map((result) => {
-                              const alreadyAttached = pendingAttachments.some(
-                                (item) => item.id === result.id,
-                              );
-                              return (
-                                <div
-                                  key={result.id}
-                                  className="flex items-center justify-between gap-2 rounded-md border border-border/70 bg-background px-3 py-2"
-                                >
-                                  <div className="min-w-0">
-                                    <p className="truncate text-sm font-medium">{result.name}</p>
-                                  </div>
-                                  <Button
-                                    type="button"
-                                    size="sm"
-                                    variant={alreadyAttached ? "secondary" : "outline"}
-                                    disabled={alreadyAttached}
-                                    aria-label={`Attach ${result.name}`}
-                                    onClick={() => addPendingAttachment(result)}
+                            {attachSearchError ? (
+                              <p className="text-sm text-destructive">{attachSearchError}</p>
+                            ) : null}
+                          </div>
+
+                          <div className="rounded-lg border border-border/70 bg-muted/20">
+                            <div className="max-h-64 space-y-2 overflow-y-auto p-2">
+                              {normalizedAttachQuery.length < 3 ? (
+                                <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                                  Search with at least 3 characters to attach a recipe.
+                                </p>
+                              ) : null}
+                              {normalizedAttachQuery.length >= 3 &&
+                              !isSearchingAttachments &&
+                              attachSearchResults.length === 0 &&
+                              !attachSearchError ? (
+                                <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+                                  No recipes found for &quot;{normalizedAttachQuery}&quot;.
+                                </p>
+                              ) : null}
+                              {attachSearchResults.map((result) => {
+                                const alreadyAttached = pendingAttachments.some(
+                                  (item) => item.id === result.id,
+                                );
+                                return (
+                                  <div
+                                    key={result.id}
+                                    className="flex items-center justify-between gap-2 rounded-md border border-border/70 bg-background px-3 py-2"
                                   >
-                                    {alreadyAttached ? "Added" : "Attach"}
-                                  </Button>
-                                </div>
-                              );
-                            })}
+                                    <div className="min-w-0">
+                                      <p className="truncate text-sm font-medium">
+                                        {result.name}
+                                      </p>
+                                    </div>
+                                    <Button
+                                      type="button"
+                                      size="sm"
+                                      variant={alreadyAttached ? "secondary" : "outline"}
+                                      disabled={alreadyAttached}
+                                      aria-label={`Attach ${result.name}`}
+                                      onClick={() => addPendingAttachment(result)}
+                                    >
+                                      {alreadyAttached ? "Added" : "Attach"}
+                                    </Button>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          </div>
+
+                          <div className="space-y-2">
+                            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                              Attached to next message
+                            </p>
+                            {pendingAttachments.length > 0 ? (
+                              <div className="flex flex-wrap gap-2">
+                                {pendingAttachments.map((attachment) => (
+                                  <Badge
+                                    key={attachment.id}
+                                    variant="secondary"
+                                    className="inline-flex items-center gap-1"
+                                  >
+                                    <span>{attachment.name}</span>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon-xs"
+                                      className="opacity-80 transition-opacity hover:opacity-100"
+                                      onClick={() => removePendingAttachment(attachment.id)}
+                                      aria-label={`Remove ${attachment.name}`}
+                                    >
+                                      <X className="size-3" />
+                                    </Button>
+                                  </Badge>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className="text-sm text-muted-foreground">
+                                No recipes attached yet.
+                              </p>
+                            )}
                           </div>
                         </div>
 
-                        <div className="space-y-2">
-                          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                            Attached to next message
+                        <DialogFooter className="border-t px-5 py-3 sm:justify-between">
+                          <p className="text-xs text-muted-foreground">
+                            {pendingAttachments.length} recipe
+                            {pendingAttachments.length === 1 ? "" : "s"} selected
                           </p>
-                          {pendingAttachments.length > 0 ? (
-                            <div className="flex flex-wrap gap-2">
-                              {pendingAttachments.map((attachment) => (
-                                <Badge
-                                  key={attachment.id}
-                                  variant="secondary"
-                                  className="inline-flex items-center gap-1"
-                                >
-                                  <span>{attachment.name}</span>
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon-xs"
-                                    className="opacity-80 transition-opacity hover:opacity-100"
-                                    onClick={() => removePendingAttachment(attachment.id)}
-                                    aria-label={`Remove ${attachment.name}`}
-                                  >
-                                    <X className="size-3" />
-                                  </Button>
-                                </Badge>
-                              ))}
-                            </div>
-                          ) : (
-                            <p className="text-sm text-muted-foreground">No recipes attached yet.</p>
-                          )}
-                        </div>
-                      </div>
+                          <Button type="button" onClick={() => setIsAttachDialogOpen(false)}>
+                            Done
+                          </Button>
+                        </DialogFooter>
+                      </DialogContent>
+                    </Dialog>
 
-                      <DialogFooter className="border-t px-5 py-3 sm:justify-between">
-                        <p className="text-xs text-muted-foreground">
-                          {pendingAttachments.length} recipe
-                          {pendingAttachments.length === 1 ? "" : "s"} selected
-                        </p>
-                        <Button type="button" onClick={() => setIsAttachDialogOpen(false)}>
-                          Done
+                    <div className="flex items-center gap-2">
+                      {latestAssistantMessage ? (
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          disabled={isBusy}
+                          onClick={handleOpenAddRecipeFlow}
+                        >
+                          <Sparkles className="size-4" />
+                          Add As Recipe
                         </Button>
-                      </DialogFooter>
-                    </DialogContent>
-                  </Dialog>
+                      ) : null}
 
-                  <div className="flex items-center gap-2">
-                    {latestAssistantMessage ? (
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        disabled={isBusy}
-                        onClick={handleOpenAddRecipeFlow}
-                      >
-                        <Sparkles className="size-4" />
-                        Add As Recipe
+                      <Button type="submit" disabled={!canSendMessage}>
+                        {isSendingMessage ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            Sending…
+                          </>
+                        ) : (
+                          <>
+                            <Send className="size-4" />
+                            Send
+                          </>
+                        )}
                       </Button>
-                    ) : null}
-
-                    <Button type="submit" disabled={!canSendMessage}>
-                      {isSendingMessage ? (
-                        <>
-                          <Loader2 className="size-4 animate-spin" />
-                          Sending…
-                        </>
-                      ) : (
-                        <>
-                          <Send className="size-4" />
-                          Send
-                        </>
-                      )}
-                    </Button>
+                    </div>
                   </div>
-                </div>
-              </form>
+                </form>
+              ) : null}
             </CardContent>
           </Card>
         </section>

--- a/apps/web/src/lib/forkfolio-api.ts
+++ b/apps/web/src/lib/forkfolio-api.ts
@@ -307,10 +307,12 @@ export async function createGroceryList(
 
 export async function createExperimentThread(
   payload: CreateExperimentThreadRequest,
+  viewerUserId?: string | null,
 ): Promise<CreateExperimentThreadResponse> {
   return forkfolioFetch<CreateExperimentThreadResponse>("/experiments/threads", {
     method: "POST",
     headers: buildHeaders({
+      ...(buildViewerHeaders(viewerUserId) ?? {}),
       "Content-Type": "application/json",
     }),
     body: JSON.stringify(payload),
@@ -320,6 +322,7 @@ export async function createExperimentThread(
 export async function listExperimentThreads(
   limit = 20,
   includeTest = false,
+  viewerUserId?: string | null,
 ): Promise<ListExperimentThreadsResponse> {
   const params = new URLSearchParams({
     limit: String(limit),
@@ -327,30 +330,39 @@ export async function listExperimentThreads(
   });
   return forkfolioFetch<ListExperimentThreadsResponse>(
     `/experiments/threads?${params.toString()}`,
+    {
+      headers: buildViewerHeaders(viewerUserId),
+    },
   );
 }
 
 export async function getExperimentThread(
   threadId: string,
   messageLimit = 120,
+  viewerUserId?: string | null,
 ): Promise<GetExperimentThreadResponse> {
   const params = new URLSearchParams({
     message_limit: String(messageLimit),
   });
   return forkfolioFetch<GetExperimentThreadResponse>(
     `/experiments/threads/${encodeURIComponent(threadId)}?${params.toString()}`,
+    {
+      headers: buildViewerHeaders(viewerUserId),
+    },
   );
 }
 
 export async function createExperimentMessage(
   threadId: string,
   payload: CreateExperimentMessageRequest,
+  viewerUserId?: string | null,
 ): Promise<CreateExperimentMessageResponse> {
   return forkfolioFetch<CreateExperimentMessageResponse>(
     `/experiments/threads/${encodeURIComponent(threadId)}/messages`,
     {
       method: "POST",
       headers: buildHeaders({
+        ...(buildViewerHeaders(viewerUserId) ?? {}),
         "Content-Type": "application/json",
       }),
       body: JSON.stringify(payload),

--- a/apps/web/src/lib/forkfolio-types.ts
+++ b/apps/web/src/lib/forkfolio-types.ts
@@ -254,6 +254,7 @@ export type ExperimentThreadRecord = {
   mode: ExperimentMode;
   title: string | null;
   metadata: Record<string, unknown>;
+  created_by_user_id?: string | null;
   context_recipe_ids: string[];
   messages: ExperimentMessageRecord[];
   created_at: string | null;
@@ -290,6 +291,7 @@ export type ExperimentThreadSummary = {
   mode: ExperimentMode;
   title: string | null;
   metadata: Record<string, unknown>;
+  created_by_user_id?: string | null;
   created_at: string | null;
   updated_at: string | null;
   last_message_role: ExperimentMessageRole | null;

--- a/apps/web/src/lib/supabase/viewer.ts
+++ b/apps/web/src/lib/supabase/viewer.ts
@@ -3,6 +3,18 @@ import "server-only";
 import { hasSupabaseAuthConfig } from "@/lib/supabase/config";
 import { createClient } from "@/lib/supabase/server";
 
+export type RequiredViewerUserIdResult =
+  | {
+      viewerUserId: string;
+      detail?: never;
+      status?: never;
+    }
+  | {
+      viewerUserId: null;
+      detail: string;
+      status: 401 | 503;
+    };
+
 export async function getOptionalViewerUserId(): Promise<string | null> {
   if (!hasSupabaseAuthConfig()) {
     return null;
@@ -15,4 +27,29 @@ export async function getOptionalViewerUserId(): Promise<string | null> {
   }
 
   return data.user.id;
+}
+
+export async function getRequiredViewerUserId(
+  featureName: string,
+  signedOutDetail = "Sign in to continue.",
+): Promise<RequiredViewerUserIdResult> {
+  if (!hasSupabaseAuthConfig()) {
+    return {
+      viewerUserId: null,
+      detail: `${featureName} require Supabase Auth configuration.`,
+      status: 503,
+    };
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) {
+    return {
+      viewerUserId: null,
+      detail: signedOutDetail,
+      status: 401,
+    };
+  }
+
+  return { viewerUserId: data.user.id };
 }

--- a/docs/experiment-thread-ownership-schema.sql
+++ b/docs/experiment-thread-ownership-schema.sql
@@ -1,0 +1,23 @@
+-- Experiment thread ownership schema update for ForkFolio.
+-- Run this after docs/supabase-auth-profile-schema.sql so public.profiles exists.
+
+alter table public.experiment_threads
+    add column if not exists created_by_user_id uuid;
+
+do $$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'experiment_threads_created_by_user_id_fkey'
+    ) then
+        alter table public.experiment_threads
+            add constraint experiment_threads_created_by_user_id_fkey
+            foreign key (created_by_user_id)
+            references public.profiles (id)
+            on delete set null;
+    end if;
+end $$;
+
+create index if not exists idx_experiment_threads_created_by_user_id
+    on public.experiment_threads(created_by_user_id);


### PR DESCRIPTION
## Summary
Add experiment thread ownership via `created_by_user_id` and include the SQL migration for `experiment_threads`.
Scope experiment thread create/list/get/message/stream operations to the requesting viewer in the backend and forward viewer IDs through the web API layer.
Require sign-in for experiment thread access in the Next.js routes and add focused tests for signed-out behavior and viewer-header forwarding.

## Testing
`npm test -- src/app/api/experiments/threads/route.test.ts 'src/app/api/experiments/threads/[threadId]/route.test.ts' 'src/app/api/experiments/threads/[threadId]/messages/route.test.ts' 'src/app/api/experiments/threads/[threadId]/messages/stream/route.test.ts'`
Backend `pytest` was not run here because `pytest` is not installed in this environment.