### PR TITLE
Remove experiment mode fallback

### DIFF
--- a/app/services/data/managers/experiment_manager.py
+++ b/app/services/data/managers/experiment_manager.py
@@ -25,33 +25,6 @@ RETURNING
     updated_at
 """
 
-THREAD_INSERT_WITH_MODE_SQL = """
-INSERT INTO experiment_threads (
-    mode,
-    title,
-    metadata,
-    created_by_user_id
-)
-VALUES (%s, %s, %s, %s)
-RETURNING
-    id,
-    title,
-    metadata,
-    created_by_user_id,
-    created_at,
-    updated_at
-"""
-
-THREAD_MODE_COLUMN_EXISTS_SQL = """
-SELECT EXISTS (
-    SELECT 1
-    FROM information_schema.columns
-    WHERE table_schema = 'public'
-      AND table_name = 'experiment_threads'
-      AND column_name = 'mode'
-) AS has_mode
-"""
-
 THREAD_OWNER_SCOPE_SQL = """
 (
     (%s IS NULL AND t.created_by_user_id IS NULL)
@@ -231,7 +204,6 @@ TEST_METADATA_SOURCE_VALUES = {
     "ci",
 }
 TRUTHY_FLAG_VALUES = {"1", "true", "yes", "y", "on"}
-DEFAULT_EXPERIMENT_THREAD_MODE = "invent_new"
 
 
 class ExperimentManager(BaseManager):
@@ -309,12 +281,6 @@ class ExperimentManager(BaseManager):
     ) -> tuple[str | None, str | None]:
         return (viewer_user_id, viewer_user_id)
 
-    @staticmethod
-    def _thread_mode_column_exists(cursor) -> bool:
-        cursor.execute(THREAD_MODE_COLUMN_EXISTS_SQL)
-        row = cursor.fetchone() or {}
-        return bool(row.get("has_mode"))
-
     def _thread_exists(
         self,
         cursor,
@@ -370,21 +336,13 @@ class ExperimentManager(BaseManager):
         metadata_payload = metadata if isinstance(metadata, dict) else {}
         try:
             with self.get_db_context() as (_conn, cursor):
-                insert_sql = THREAD_INSERT_SQL
-                insert_params: tuple[Any, ...] = (
-                    title,
-                    Json(metadata_payload),
-                    created_by_user_id,
-                )
-                if self._thread_mode_column_exists(cursor):
-                    insert_sql = THREAD_INSERT_WITH_MODE_SQL
-                    insert_params = (
-                        DEFAULT_EXPERIMENT_THREAD_MODE,
-                        *insert_params,
-                    )
                 cursor.execute(
-                    insert_sql,
-                    insert_params,
+                    THREAD_INSERT_SQL,
+                    (
+                        title,
+                        Json(metadata_payload),
+                        created_by_user_id,
+                    ),
                 )
                 row = cursor.fetchone()
                 if row is None:

--- a/app/tests/unit/test_experiment_service_guardrails.py
+++ b/app/tests/unit/test_experiment_service_guardrails.py
@@ -297,7 +297,6 @@ def test_create_thread_insert_omits_mode_column(monkeypatch) -> None:
     manager = ExperimentManager()
     cursor = FakeCursor(
         fetchone_results=[
-            {"has_mode": False},
             {
                 "id": "thread-1",
                 "title": "Weeknight curry",
@@ -317,7 +316,7 @@ def test_create_thread_insert_omits_mode_column(monkeypatch) -> None:
     )
 
     assert thread["id"] == "thread-1"
-    query, params = cursor.executed[1]
+    query, params = cursor.executed[0]
     assert "INSERT INTO experiment_threads" in query
     assert "mode" not in query
     assert len(params) == 3
@@ -325,38 +324,3 @@ def test_create_thread_insert_omits_mode_column(monkeypatch) -> None:
     assert isinstance(params[1], Json)
     assert params[1].adapted == {"orchestration": "langgraph-ready"}
     assert params[2] == "user-123"
-
-
-def test_create_thread_insert_includes_mode_column_when_present(monkeypatch) -> None:
-    manager = ExperimentManager()
-    cursor = FakeCursor(
-        fetchone_results=[
-            {"has_mode": True},
-            {
-                "id": "thread-legacy",
-                "title": "Legacy curry",
-                "metadata": {"orchestration": "langgraph-ready"},
-                "created_by_user_id": "user-456",
-                "created_at": None,
-                "updated_at": None,
-            },
-        ]
-    )
-    _patch_db_context(monkeypatch, manager, cursor)
-
-    thread = manager.create_thread(
-        title="Legacy curry",
-        metadata={"orchestration": "langgraph-ready"},
-        created_by_user_id="user-456",
-    )
-
-    assert thread["id"] == "thread-legacy"
-    query, params = cursor.executed[1]
-    assert "INSERT INTO experiment_threads" in query
-    assert "mode" in query
-    assert len(params) == 4
-    assert params[0] == "invent_new"
-    assert params[1] == "Legacy curry"
-    assert isinstance(params[2], Json)
-    assert params[2].adapted == {"orchestration": "langgraph-ready"}
-    assert params[3] == "user-456"

--- a/docs/experiment-thread-drop-mode-column.sql
+++ b/docs/experiment-thread-drop-mode-column.sql
@@ -1,2 +1,0 @@
-alter table public.experiment_threads
-    drop column if exists mode;


### PR DESCRIPTION
Removes the temporary dual-schema fallback added during the `experiment_threads.mode` column rollout now that the column has been dropped. Simplifies thread creation back to a single insert path, trims the legacy-schema-only unit coverage, and deletes the one-off SQL drop script.

Testing: `pytest app/tests/unit/test_experiment_service_guardrails.py app/tests/unit/test_experiments_endpoints.py`; `ruff format --check app/services/data/managers/experiment_manager.py app/tests/unit/test_experiment_service_guardrails.py`