### PR TITLE
Add PostHog analytics to the web app

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,6 +14,14 @@ Search-first frontend for ForkFolio, built with Next.js + `shadcn/ui`.
    - `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (required for Google sign-in)
    - `FORKFOLIO_APP_ORIGIN` (optional but recommended in production; canonical app origin for auth callback redirects)
 
+PostHog is wired conservatively:
+- the frontend PostHog project token and app identity are checked into the web app, so analytics does not require extra `.env` entries
+- automatic pageviews are enabled
+- broad autocapture is disabled to avoid noisy or sensitive form data from recipe imports
+- session replay is disabled by default
+- custom events include sign-in, search, recipe import, bag actions, recipe books, and grocery-list generation
+- every event carries app-level properties so dashboards can filter this app inside a shared PostHog project
+
 ## Run
 
 ```bash

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -14,6 +14,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.576.0",
         "next": "16.1.6",
+        "posthog-js": "^1.373.5",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -2462,6 +2463,332 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.2.tgz",
+      "integrity": "sha512-DYhR0Sl7pVdUXa+C9poCVjTj3D6SI9P7RLhIhr74YyHeHuCGL/MZsDEWcz3ul3qHDIhZU9myIUjID890QiQw+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.373.5"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.373.5",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.373.5.tgz",
+      "integrity": "sha512-K7STCnRG/WBE1q0BwEkIcrJB5OqECaymsQj6Hp4Ntvaek4dqHkZGfp6hxwIPqQPjlOXwidwPLo+XGsn+CoZUyw==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "license": "MIT"
@@ -4900,6 +5227,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -6473,6 +6807,17 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "dev": true,
@@ -6855,6 +7200,15 @@
       "version": "0.5.16",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -7829,6 +8183,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -9676,6 +10036,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -11505,6 +11871,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.373.5",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.373.5.tgz",
+      "integrity": "sha512-VjeSKiAtbRxcKXr+lFWlHNd9GGxA3A1gZ87EsIZmEV3N8SwO11uAf6JDTEuymdUNGn99XTvWcPrBCxkSBgVAEg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.29.2",
+        "@posthog/types": "1.373.5",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "dev": true,
@@ -11514,6 +11901,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -11607,6 +12004,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "dev": true,
@@ -11640,6 +12061,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -13877,6 +14304,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.576.0",
     "next": "16.1.6",
+    "posthog-js": "^1.373.5",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/web/src/app/bag/page.tsx
+++ b/apps/web/src/app/bag/page.tsx
@@ -17,6 +17,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { CreateGroceryListResponse } from "@/lib/forkfolio-types";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 
 type ErrorPayload = {
   detail?: string;
@@ -114,6 +116,10 @@ export default function GroceryBagPage() {
         return;
       }
       setGeneratedList(response);
+      capturePostHogEvent(POSTHOG_EVENT.GroceryListGenerated, {
+        ingredient_count: response.count,
+        recipe_count: response.recipe_ids.length,
+      });
     } catch (error) {
       if (generationRequestIdRef.current !== requestId) {
         return;

--- a/apps/web/src/app/books/page.tsx
+++ b/apps/web/src/app/books/page.tsx
@@ -25,6 +25,8 @@ import type {
   RecipeBookRecord,
   RecipeBookStats,
 } from "@/lib/forkfolio-types";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 
 type ErrorPayload = {
   detail?: string;
@@ -209,6 +211,11 @@ export default function RecipeBooksPage() {
 
     try {
       const response = await createRecipeBookClient(trimmedName, description.trim());
+      capturePostHogEvent(POSTHOG_EVENT.RecipeBookCreated, {
+        has_description: Boolean(description.trim()),
+        recipe_book_id: response.recipe_book.id,
+        returned_existing: !response.created,
+      });
       setCreateResult({
         created: response.created,
         id: response.recipe_book.id,

--- a/apps/web/src/app/browse/use-browse-data.ts
+++ b/apps/web/src/app/browse/use-browse-data.ts
@@ -8,6 +8,8 @@ import type {
   RecipeRecord,
   SearchRecipeResult,
 } from "@/lib/forkfolio-types";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 
 import {
   MIN_QUERY_LENGTH,
@@ -616,6 +618,12 @@ export function useBrowseData() {
       return;
     }
 
+    if (normalizedQuery.length >= MIN_QUERY_LENGTH) {
+      capturePostHogEvent(POSTHOG_EVENT.RecipesSearched, {
+        query_length: normalizedQuery.length,
+      });
+    }
+
     setBrowseUrl(normalizedQuery, undefined, "push");
   }
 
@@ -628,6 +636,11 @@ export function useBrowseData() {
   }
 
   function openRecipeModal(recipeId: string) {
+    capturePostHogEvent(POSTHOG_EVENT.RecipeViewed, {
+      recipe_id: recipeId,
+      searched: Boolean(queryFromUrl),
+      source: "browse_modal",
+    });
     setBrowseUrl(queryFromUrl, recipeId, "push");
   }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Playfair_Display, Source_Sans_3 } from "next/font/google";
 
 import { GroceryBagProvider } from "@/components/grocery-bag-provider";
+import { PostHogAuthTracker } from "@/components/posthog-auth-tracker";
 
 import "./globals.css";
 
@@ -28,7 +29,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${sourceSans.variable} ${playfair.variable} antialiased`}>
-        <GroceryBagProvider>{children}</GroceryBagProvider>
+        <PostHogAuthTracker>
+          <GroceryBagProvider>{children}</GroceryBagProvider>
+        </PostHogAuthTracker>
       </body>
     </html>
   );

--- a/apps/web/src/app/recipes/new/page.tsx
+++ b/apps/web/src/app/recipes/new/page.tsx
@@ -24,10 +24,12 @@ import { consumeExperimentRecipeDraft } from "@/lib/experiment-recipe-draft";
 import {
   MIN_RECIPE_INPUT_LENGTH,
   type PreviewRecipeFromUrlResponse,
-  type RecipePreviewRecord,
   type ProcessRecipeResponse,
   type ProcessRecipeSuccessResponse,
+  type RecipePreviewRecord,
 } from "@/lib/forkfolio-types";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 
 type ErrorPayload = {
   detail?: string;
@@ -158,6 +160,22 @@ function formatRecipePreviewAsRawInput(preview: RecipePreviewRecord): string {
   ].join("\n");
 }
 
+function captureRecipeImportEvent(options: {
+  created?: boolean;
+  inputMode: "text" | "url_preview";
+  isPublic: boolean;
+  sourceUrlPresent: boolean;
+  success: boolean;
+}) {
+  capturePostHogEvent(POSTHOG_EVENT.RecipeImported, {
+    created: options.created ?? false,
+    input_mode: options.inputMode,
+    is_public: options.isPublic,
+    source_url_present: options.sourceUrlPresent,
+    success: options.success,
+  });
+}
+
 function SuccessState({
   result,
   onStartOver,
@@ -276,10 +294,23 @@ export default function NewRecipePage() {
         textModeSourceUrl ?? undefined,
       );
       setResult(response);
+      captureRecipeImportEvent({
+        created: response.success ? response.created : false,
+        inputMode: "text",
+        isPublic,
+        sourceUrlPresent: Boolean(textModeSourceUrl),
+        success: response.success,
+      });
       if (!response.success) {
         setErrorMessage(response.error || "Recipe processing failed.");
       }
     } catch (error) {
+      captureRecipeImportEvent({
+        inputMode: "text",
+        isPublic,
+        sourceUrlPresent: Boolean(textModeSourceUrl),
+        success: false,
+      });
       setErrorMessage(getSaveErrorMessage(error, "Recipe processing failed."));
     } finally {
       setIsSubmitting(false);
@@ -302,10 +333,18 @@ export default function NewRecipePage() {
     try {
       const response = await previewRecipeFromUrlClient(normalizedSourceUrl);
       setPreviewResult(response);
+      capturePostHogEvent(POSTHOG_EVENT.RecipePreviewFetched, {
+        ingredient_count: response.success ? response.recipe_preview.ingredients.length : 0,
+        instruction_count: response.success ? response.recipe_preview.instructions.length : 0,
+        success: response.success,
+      });
       if (!response.success) {
         setPreviewErrorMessage(response.error || "Recipe preview failed.");
       }
     } catch (error) {
+      capturePostHogEvent(POSTHOG_EVENT.RecipePreviewFetched, {
+        success: false,
+      });
       setPreviewErrorMessage(
         getErrorMessage(error, "Failed to fetch recipe preview from URL."),
       );
@@ -328,6 +367,13 @@ export default function NewRecipePage() {
         sourceUrlForSave,
       );
       setResult(response);
+      captureRecipeImportEvent({
+        created: response.success ? response.created : false,
+        inputMode: "url_preview",
+        isPublic,
+        sourceUrlPresent: Boolean(sourceUrlForSave),
+        success: response.success,
+      });
       if (response.success) {
         setPreviewResult(null);
         setSourceUrl("");
@@ -336,6 +382,12 @@ export default function NewRecipePage() {
         setErrorMessage(response.error || "Recipe processing failed.");
       }
     } catch (error) {
+      captureRecipeImportEvent({
+        inputMode: "url_preview",
+        isPublic,
+        sourceUrlPresent: Boolean(sourceUrlForSave),
+        success: false,
+      });
       setErrorMessage(getSaveErrorMessage(error, "Recipe processing failed."));
     } finally {
       setIsSavingPreview(false);

--- a/apps/web/src/components/auth-profile-button.tsx
+++ b/apps/web/src/components/auth-profile-button.tsx
@@ -16,6 +16,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 import { createClient } from "@/lib/supabase/client";
 import { hasSupabaseAuthConfig } from "@/lib/supabase/config";
 
@@ -137,7 +139,17 @@ export function AuthProfileButton() {
 
     setErrorMessage(null);
 
+    const authProvider =
+      typeof currentUser?.app_metadata?.provider === "string"
+        ? currentUser.app_metadata.provider
+        : "supabase";
+
     startTransition(() => {
+      capturePostHogEvent(POSTHOG_EVENT.UserSignedOut, {
+        auth_provider: authProvider,
+        current_path: pathname,
+      });
+
       void supabase.auth.signOut().then(({ error }) => {
         if (error) {
           setErrorMessage(error.message);

--- a/apps/web/src/components/grocery-bag-provider.tsx
+++ b/apps/web/src/components/grocery-bag-provider.tsx
@@ -11,6 +11,8 @@ import {
 } from "react";
 
 import type { GroceryBagItem, GroceryBagRecipe } from "@/lib/forkfolio-types";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 
 const GROCERY_BAG_STORAGE_KEY = "forkfolio.grocery-bag.v1";
 
@@ -133,6 +135,15 @@ export function GroceryBagProvider({ children }: { children: ReactNode }) {
         return;
       }
 
+      if (items.some((item) => item.id === normalizedRecipeId)) {
+        return;
+      }
+
+      capturePostHogEvent(POSTHOG_EVENT.RecipeAddedToBag, {
+        bag_size: items.length + 1,
+        recipe_id: normalizedRecipeId,
+      });
+
       setItems((prev) => {
         if (prev.some((item) => item.id === normalizedRecipeId)) {
           return prev;
@@ -157,10 +168,28 @@ export function GroceryBagProvider({ children }: { children: ReactNode }) {
       if (!normalizedRecipeId) {
         return;
       }
+
+      if (!items.some((item) => item.id === normalizedRecipeId)) {
+        return;
+      }
+
+      capturePostHogEvent(POSTHOG_EVENT.RecipeRemovedFromBag, {
+        bag_size: Math.max(0, items.length - 1),
+        recipe_id: normalizedRecipeId,
+      });
+
       setItems((prev) => prev.filter((item) => item.id !== normalizedRecipeId));
     }
 
     function clearBag(): void {
+      if (items.length === 0) {
+        return;
+      }
+
+      capturePostHogEvent(POSTHOG_EVENT.BagCleared, {
+        previous_bag_size: items.length,
+      });
+
       setItems([]);
     }
 

--- a/apps/web/src/components/posthog-auth-tracker.tsx
+++ b/apps/web/src/components/posthog-auth-tracker.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { User } from "@supabase/supabase-js";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import {
+  capturePostHogEvent,
+  identifyPostHogUser,
+  resetPostHogUser,
+} from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
+import { createClient } from "@/lib/supabase/client";
+import { hasSupabaseAuthConfig } from "@/lib/supabase/config";
+
+function resolveDisplayName(user: User): string | null {
+  const fullName = typeof user.user_metadata?.full_name === "string"
+    ? user.user_metadata.full_name.trim()
+    : "";
+  if (fullName) {
+    return fullName;
+  }
+
+  const name = typeof user.user_metadata?.name === "string"
+    ? user.user_metadata.name.trim()
+    : "";
+  if (name) {
+    return name;
+  }
+
+  const emailPrefix = user.email?.split("@", 1)[0]?.trim();
+  return emailPrefix || null;
+}
+
+function resolveAuthProvider(user: User): string {
+  const provider = user.app_metadata?.provider;
+  return typeof provider === "string" && provider.trim() ? provider : "supabase";
+}
+
+export function PostHogAuthTracker({ children }: { children: ReactNode }) {
+  const [supabase] = useState(() => (
+    hasSupabaseAuthConfig() ? createClient() : null
+  ));
+  const previousUserIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!supabase) {
+      return;
+    }
+
+    let isActive = true;
+
+    function syncUser(user: User | null) {
+      if (user) {
+        identifyPostHogUser({
+          authProvider: resolveAuthProvider(user),
+          email: user.email ?? null,
+          id: user.id,
+          name: resolveDisplayName(user),
+        });
+      } else if (previousUserIdRef.current) {
+        resetPostHogUser();
+      }
+
+      previousUserIdRef.current = user?.id ?? null;
+    }
+
+    void supabase.auth.getUser().then(({ data }) => {
+      if (!isActive) {
+        return;
+      }
+
+      syncUser(data.user ?? null);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (!isActive) {
+        return;
+      }
+
+      const previousUserId = previousUserIdRef.current;
+      const nextUser = session?.user ?? null;
+
+      syncUser(nextUser);
+
+      if (event === "SIGNED_IN" && nextUser && previousUserId !== nextUser.id) {
+        capturePostHogEvent(POSTHOG_EVENT.UserAuthenticated, {
+          auth_provider: resolveAuthProvider(nextUser),
+          has_verified_email: Boolean(nextUser.email_confirmed_at),
+        });
+      }
+    });
+
+    return () => {
+      isActive = false;
+      subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/recipe-book-membership.tsx
+++ b/apps/web/src/components/recipe-book-membership.tsx
@@ -21,6 +21,8 @@ import type {
   RecipeBookRecord,
   RemoveRecipeFromBookResponse,
 } from "@/lib/forkfolio-types";
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 
 type ErrorPayload = {
   detail?: string;
@@ -172,6 +174,12 @@ export function RecipeBookMembership({ recipeId }: { recipeId: string }) {
       } else {
         await addRecipeToBookClient(recipeBookId, recipeId);
       }
+
+      capturePostHogEvent(POSTHOG_EVENT.RecipeBookMembershipUpdated, {
+        action: isMember ? "removed" : "added",
+        recipe_book_id: recipeBookId,
+        recipe_id: recipeId,
+      });
 
       setMemberBookIds((prev) => {
         const next = new Set(prev);

--- a/apps/web/src/components/track-recipe-history.tsx
+++ b/apps/web/src/components/track-recipe-history.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from "react";
 
+import { capturePostHogEvent } from "@/lib/posthog/client";
+import { POSTHOG_EVENT } from "@/lib/posthog/events";
 import { writeRecentRecipe } from "@/lib/recent-recipes";
 
 export function TrackRecipeHistory({
@@ -18,6 +20,10 @@ export function TrackRecipeHistory({
     writeRecentRecipe(window.localStorage, {
       id: recipeId,
       title: recipeTitle,
+    });
+    capturePostHogEvent(POSTHOG_EVENT.RecipeViewed, {
+      recipe_id: recipeId,
+      source: "recipe_page",
     });
   }, [recipeId, recipeTitle]);
 

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -1,0 +1,3 @@
+import { initPostHog } from "@/lib/posthog/client";
+
+initPostHog();

--- a/apps/web/src/lib/posthog/client.ts
+++ b/apps/web/src/lib/posthog/client.ts
@@ -1,0 +1,114 @@
+import posthog from "posthog-js";
+
+import {
+  getPostHogAppName,
+  getPostHogAppProperties,
+  getPostHogPublicConfig,
+  hasPostHogConfig,
+  type PostHogViewerState,
+} from "@/lib/posthog/config";
+
+type PostHogCaptureProperties = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+type IdentifyUserArgs = {
+  authProvider?: string | null;
+  email?: string | null;
+  id: string;
+  name?: string | null;
+};
+
+let hasInitializedPostHog = false;
+
+function registerViewerContext(
+  viewerState: PostHogViewerState,
+  authenticatedUserId?: string,
+): void {
+  posthog.register({
+    ...getPostHogAppProperties(),
+    viewer_state: viewerState,
+    ...(authenticatedUserId
+      ? { authenticated_app_user_id: authenticatedUserId }
+      : {}),
+  });
+
+  if (!authenticatedUserId) {
+    posthog.unregister("authenticated_app_user_id");
+  }
+}
+
+export function initPostHog(): void {
+  if (typeof window === "undefined" || hasInitializedPostHog || !hasPostHogConfig()) {
+    return;
+  }
+
+  const { token, host } = getPostHogPublicConfig();
+
+  try {
+    posthog.init(token, {
+      api_host: host,
+      autocapture: false,
+      capture_pageleave: "if_capture_pageview",
+      capture_pageview: "history_change",
+      defaults: "2026-01-30",
+      disable_session_recording: true,
+      person_profiles: "identified_only",
+      loaded: () => {
+        registerViewerContext("anonymous");
+      },
+    });
+
+    hasInitializedPostHog = true;
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("PostHog initialization failed.", error);
+    }
+  }
+}
+
+export function capturePostHogEvent(
+  eventName: string,
+  properties?: PostHogCaptureProperties,
+): void {
+  if (!hasPostHogConfig()) {
+    return;
+  }
+
+  posthog.capture(eventName, properties);
+}
+
+export function identifyPostHogUser({
+  authProvider,
+  email,
+  id,
+  name,
+}: IdentifyUserArgs): void {
+  if (!hasPostHogConfig()) {
+    return;
+  }
+
+  posthog.identify(
+    id,
+    {
+      auth_provider: authProvider ?? "supabase",
+      email: email ?? undefined,
+      name: name ?? undefined,
+    },
+    {
+      first_seen_app: getPostHogAppName(),
+    },
+  );
+
+  registerViewerContext("authenticated", id);
+}
+
+export function resetPostHogUser(): void {
+  if (!hasPostHogConfig()) {
+    return;
+  }
+
+  posthog.reset();
+  registerViewerContext("anonymous");
+}

--- a/apps/web/src/lib/posthog/config.ts
+++ b/apps/web/src/lib/posthog/config.ts
@@ -1,0 +1,48 @@
+export type PostHogViewerState = "anonymous" | "authenticated";
+
+const posthogToken = "phc_ApXgcUDQgbUF7oFBWW3d2DtFbFvHKeE3estJyaoxcLVS";
+const posthogHost = "https://us.i.posthog.com";
+const posthogAppName = "forkfolio-web";
+const posthogAppNamespace = "forkfolio";
+
+function getDeploymentEnvironment(): string {
+  if (typeof window !== "undefined") {
+    const hostname = window.location.hostname.trim().toLowerCase();
+
+    if (!hostname || hostname === "localhost" || hostname === "127.0.0.1") {
+      return "local";
+    }
+
+    if (hostname.includes("staging")) {
+      return "staging";
+    }
+
+    return "production";
+  }
+
+  return process.env.NODE_ENV?.trim() || "development";
+}
+
+export function hasPostHogConfig(): boolean {
+  return Boolean(posthogToken);
+}
+
+export function getPostHogPublicConfig() {
+  return {
+    token: posthogToken,
+    host: posthogHost,
+  };
+}
+
+export function getPostHogAppProperties() {
+  return {
+    app_name: posthogAppName,
+    app_namespace: posthogAppNamespace,
+    app_platform: "web" as const,
+    deployment_environment: getDeploymentEnvironment(),
+  };
+}
+
+export function getPostHogAppName(): string {
+  return posthogAppName;
+}

--- a/apps/web/src/lib/posthog/events.ts
+++ b/apps/web/src/lib/posthog/events.ts
@@ -1,0 +1,14 @@
+export const POSTHOG_EVENT = {
+  BagCleared: "bag cleared",
+  GroceryListGenerated: "grocery list generated",
+  RecipeAddedToBag: "recipe added to bag",
+  RecipeBookCreated: "recipe book created",
+  RecipeBookMembershipUpdated: "recipe book membership updated",
+  RecipeImported: "recipe import completed",
+  RecipePreviewFetched: "recipe preview fetched",
+  RecipeRemovedFromBag: "recipe removed from bag",
+  RecipeViewed: "recipe viewed",
+  RecipesSearched: "recipes searched",
+  UserAuthenticated: "user authenticated",
+  UserSignedOut: "user signed out",
+} as const;


### PR DESCRIPTION
## Summary
- add a deploy-agnostic PostHog browser bootstrap with auth-aware identify/reset for the shared web app
- capture core product events for search, recipe imports, bag actions, recipe books, grocery lists, and recipe views
- keep PostHog config out of the env contract and document the analytics behavior in the web README

## Testing
- npm --prefix apps/web run lint
- npm --prefix apps/web run test
- npm --prefix apps/web run build