### PR TITLE
[codex] Polish hybrid search naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Core capabilities:
 
 - Process and store recipes from raw text.
 - Preview recipe extraction from URL before saving.
-- Semantic search over recipes.
+- Hybrid search over recipes.
 - Recipe books (create/list/detail/add/remove).
 - Grocery list aggregation from selected recipes.
 - Recipe deletion and custom not-found UX on the frontend.

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -9,7 +9,7 @@ from app.api.schemas import (
 )
 from app.api.v1.helpers.recipe_search import normalize_search_query
 from app.api.v1.helpers.recipe_pagination import RecipePaginationCursor
-from app.core.cache import hash_cache_key, semantic_search_cache
+from app.core.cache import hash_cache_key, hybrid_search_cache
 from app.core.config import settings
 from app.core.dependencies import (
     get_grocery_list_aggregation_service,
@@ -34,7 +34,7 @@ recipe_hybrid_search_service_dep = Depends(get_recipe_hybrid_search_service)
 grocery_list_aggregation_service_dep = Depends(get_grocery_list_aggregation_service)
 
 
-def _semantic_search_cache_key(
+def _hybrid_search_cache_key(
     normalized_query: str,
     limit: int,
     include_test_data: bool,
@@ -43,7 +43,7 @@ def _semantic_search_cache_key(
 ) -> str:
     fts_weight, trigram_weight, vector_weight = weights
     return hash_cache_key(
-        "semantic_search",
+        "hybrid_search",
         normalized_query,
         str(limit),
         str(include_test_data),
@@ -144,7 +144,7 @@ def process_and_store_recipe(
             status_code=500,
             detail="Recipe stored but could not be retrieved",
         )
-    semantic_search_cache.clear()
+    hybrid_search_cache.clear()
 
     return {
         "recipe_id": recipe_id,
@@ -268,7 +268,7 @@ def list_recipes(
 
 
 @router.get("/search/semantic")
-def semantic_search_recipes(
+def hybrid_search_recipes(
     request: Request,
     query: str = Query(
         ...,
@@ -302,22 +302,22 @@ def semantic_search_recipes(
         )
     viewer_user_id = _viewer_user_id_from_request(request)
     normalized_weights = search_service.normalized_weights()
-    cache_key = _semantic_search_cache_key(
+    cache_key = _hybrid_search_cache_key(
         normalized_query=normalized_query,
         limit=limit,
         include_test_data=include_test_data,
         viewer_user_id=viewer_user_id,
         weights=normalized_weights,
     )
-    cached_response = semantic_search_cache.get(cache_key)
+    cached_response = hybrid_search_cache.get(cache_key)
     if cached_response is not None:
         logger.info(
-            "Semantic search cache hit query='%s' limit=%s", normalized_query, limit
+            "Hybrid search cache hit query='%s' limit=%s", normalized_query, limit
         )
         return cached_response
 
     logger.info(
-        "Semantic search query='%s' limit=%s weights=(fts=%.2f trigram=%.2f vector=%.2f)",
+        "Hybrid search query='%s' limit=%s weights=(fts=%.2f trigram=%.2f vector=%.2f)",
         normalized_query,
         limit,
         normalized_weights[0],
@@ -340,13 +340,13 @@ def semantic_search_recipes(
             "results": matches,
             "success": True,
         }
-        semantic_search_cache.set(cache_key, response_payload)
+        hybrid_search_cache.set(cache_key, response_payload)
         return response_payload
     except Exception as e:
-        logger.error(f"Error performing semantic search: {e!s}")
+        logger.error(f"Error performing hybrid search: {e!s}")
         raise HTTPException(
             status_code=500,
-            detail=f"Error performing semantic search: {e!s}",
+            detail=f"Error performing hybrid search: {e!s}",
         ) from e
 
 
@@ -513,7 +513,7 @@ def delete_recipe(recipe_id: str, recipe_manager=recipe_manager_dep) -> bool:
         if not deleted:
             logger.warning(f"Recipe not found for delete: {recipe_id}")
             raise HTTPException(status_code=404, detail="Recipe not found")
-        semantic_search_cache.clear()
+        hybrid_search_cache.clear()
         return True
     except HTTPException:
         raise

--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -96,7 +96,7 @@ embedding_cache: TTLCache[list[float]] = TTLCache(
     ttl_seconds=EMBEDDING_CACHE_TTL_SECONDS,
     max_items=EMBEDDING_CACHE_MAX_ITEMS,
 )
-semantic_search_cache: TTLCache[dict] = TTLCache(
+hybrid_search_cache: TTLCache[dict] = TTLCache(
     ttl_seconds=SEMANTIC_SEARCH_CACHE_TTL_SECONDS,
     max_items=SEMANTIC_SEARCH_CACHE_MAX_ITEMS,
 )

--- a/app/services/data/managers/recipe_manager.py
+++ b/app/services/data/managers/recipe_manager.py
@@ -352,7 +352,7 @@ class RecipeManager(BaseManager):
         return embeddings
 
     @staticmethod
-    def _format_semantic_search_row(row: dict) -> dict:
+    def _format_hybrid_search_row(row: dict) -> dict:
         recipe_id = row.get("recipe_id")
         distance_value = row.get("distance")
         distance = float(distance_value) if distance_value is not None else None
@@ -700,7 +700,7 @@ class RecipeManager(BaseManager):
                     ),
                 )
                 rows = cursor.fetchall()
-                return [self._format_semantic_search_row(dict(row)) for row in rows]
+                return [self._format_hybrid_search_row(dict(row)) for row in rows]
         except Exception as e:
             raise DatabaseError(
                 f"Failed to search recipes by hybrid ranking: {e!s}"

--- a/app/tests/clients/recipes_client.py
+++ b/app/tests/clients/recipes_client.py
@@ -18,7 +18,7 @@ class RecipesClient(BaseAPIClient):
     PROCESS_AND_STORE_ENDPOINT = f"{settings.API_BASE_PATH}/recipes/process-and-store"
     LIST_RECIPES_ENDPOINT = f"{settings.API_BASE_PATH}/recipes/"
     PREVIEW_FROM_URL_ENDPOINT = f"{settings.API_BASE_PATH}/recipes/preview-from-url"
-    SEMANTIC_SEARCH_ENDPOINT = f"{settings.API_BASE_PATH}/recipes/search/semantic"
+    HYBRID_SEARCH_ENDPOINT = f"{settings.API_BASE_PATH}/recipes/search/semantic"
     GROCERY_LIST_ENDPOINT = f"{settings.API_BASE_PATH}/recipes/grocery-list"
 
     def process_and_store_recipe(
@@ -107,20 +107,20 @@ class RecipesClient(BaseAPIClient):
         endpoint = f"{settings.API_BASE_PATH}/recipes/delete/{recipe_id}"
         return self.delete(endpoint)
 
-    def search_semantic(
+    def search_hybrid(
         self,
         query: str,
         limit: int = 10,
         include_test_data: bool = True,
     ) -> Dict[str, Any]:
         """
-        Hybrid semantic search over recipes using Postgres-native ranking.
+        Hybrid recipe search over recipes using Postgres-native ranking.
 
         Endpoint: GET /api/v1/recipes/search/semantic
-        Router: app.api.v1.endpoints.recipes:semantic_search_recipes
+        Router: app.api.v1.endpoints.recipes:hybrid_search_recipes
         """
         return self.get(
-            self.SEMANTIC_SEARCH_ENDPOINT,
+            self.HYBRID_SEARCH_ENDPOINT,
             params={
                 "query": query,
                 "limit": limit,

--- a/app/tests/e2e/test_recipe_semantic_search.py
+++ b/app/tests/e2e/test_recipe_semantic_search.py
@@ -1,4 +1,4 @@
-"""E2E coverage for semantic recipe search."""
+"""E2E coverage for hybrid recipe search."""
 
 import uuid
 
@@ -7,7 +7,7 @@ from app.tests.utils.constants import HTTP_OK
 from app.tests.utils.helpers import maybe_throttle
 
 
-def test_semantic_search_finds_newly_stored_recipe(api_client: APIClient) -> None:
+def test_hybrid_search_finds_newly_stored_recipe(api_client: APIClient) -> None:
     run_id = uuid.uuid4().hex[:8]
     input_text = (
         f"Semantic Citrus Pasta {run_id}\n\n"
@@ -40,7 +40,7 @@ def test_semantic_search_finds_newly_stored_recipe(api_client: APIClient) -> Non
 
         # Quote-wrapped query also validates endpoint-side query normalization.
         maybe_throttle()
-        search_response = api_client.recipes.search_semantic(
+        search_response = api_client.recipes.search_hybrid(
             query=f'"{stored_title}"',
             limit=10,
         )
@@ -53,7 +53,7 @@ def test_semantic_search_finds_newly_stored_recipe(api_client: APIClient) -> Non
 
         result_ids = [result.get("id") for result in results]
         assert recipe_id in result_ids, (
-            f"Expected recipe {recipe_id} in semantic results for '{stored_title}', "
+            f"Expected recipe {recipe_id} in hybrid search results for '{stored_title}', "
             f"got ids={result_ids}"
         )
     finally:

--- a/app/tests/unit/test_recipe_semantic_search_endpoint.py
+++ b/app/tests/unit/test_recipe_semantic_search_endpoint.py
@@ -71,7 +71,7 @@ def build_client(
     search_service: FakeHybridSearchService | None = None,
     embeddings_service: FakeEmbeddingsService | None = None,
 ) -> TestClient:
-    recipes.semantic_search_cache.clear()
+    recipes.hybrid_search_cache.clear()
     app = FastAPI()
     app.include_router(recipes.router)
     if embeddings_service is not None:
@@ -132,7 +132,7 @@ def test_semantic_search_reuses_cached_response(monkeypatch) -> None:
     fake_embeddings = FakeEmbeddingsService(embedding=[0.4, 0.5, 0.6])
     monkeypatch.setattr(
         recipes,
-        "semantic_search_cache",
+        "hybrid_search_cache",
         TTLCache[dict](ttl_seconds=300, max_items=32),
     )
     client = build_client(
@@ -156,7 +156,7 @@ def test_semantic_search_cache_key_uses_normalized_weights(monkeypatch) -> None:
     fake_embeddings = FakeEmbeddingsService(embedding=[0.4, 0.5, 0.6])
     monkeypatch.setattr(
         recipes,
-        "semantic_search_cache",
+        "hybrid_search_cache",
         TTLCache[dict](ttl_seconds=300, max_items=32),
     )
     client = build_client(
@@ -249,7 +249,7 @@ def test_semantic_search_returns_500_on_embedding_error() -> None:
 
     assert response.status_code == 500
     assert (
-        response.json()["detail"] == "Error performing semantic search: embeddings down"
+        response.json()["detail"] == "Error performing hybrid search: embeddings down"
     )
 
 
@@ -263,7 +263,7 @@ def test_semantic_search_returns_500_on_search_error() -> None:
     response = client.get(SEARCH_PATH, params={"query": "lasagna"})
 
     assert response.status_code == 500
-    assert response.json()["detail"] == "Error performing semantic search: search down"
+    assert response.json()["detail"] == "Error performing hybrid search: search down"
 
 
 def test_semantic_search_strips_wrapping_quotes() -> None:

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -59,7 +59,7 @@ App pages:
 
 Auth and internal API routes:
 - `/auth/callback` Supabase OAuth code exchange route
-- `/api/search` semantic search proxy route
+- `/api/search` hybrid search proxy route
 - `/api/recipes` recipe list proxy route
 - `/api/recipes/[recipeId]` recipe detail proxy route
 - `/api/recipes/process` process-and-store proxy route

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -49,7 +49,7 @@ const FEATURE_CARDS = [
   {
     id: "browse",
     title: "Browse & Search",
-    description: "Use semantic search to find recipes by ingredients, cuisines, or meal type.",
+    description: "Use hybrid search to find recipes by ingredients, cuisines, or meal type.",
     href: "/browse",
     cta: "Open Search",
   },

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -296,6 +296,8 @@ Auth: Required
 Performs hybrid recipe search using PostgreSQL full-text search, `pg_trgm`,
 and `pgvector`.
 
+The route keeps the `/search/semantic` path for backward compatibility.
+
 Query parameters:
 
 - `query` (string, required, minimum 2 non-whitespace chars)

--- a/docs/engineering-architecture.md
+++ b/docs/engineering-architecture.md
@@ -7,7 +7,7 @@ This document contains implementation-focused details that are intentionally sep
 ForkFolio is a FastAPI service with three main concerns:
 
 - API routing and request protection middleware.
-- AI-powered recipe ingestion and semantic retrieval.
+- AI-powered recipe ingestion and hybrid retrieval.
 - PostgreSQL-backed persistence (Supabase) with connection pooling.
 
 The web frontend (`apps/web`) consumes these APIs and includes Supabase Google
@@ -35,7 +35,7 @@ OAuth session handling for profile-aware UI state.
 ## Data and Processing Notes
 
 - Recipe ingestion pipeline combines cleanup, extraction, deduplication, embedding generation, and storage.
-- Semantic search is backed by embedding similarity checks against stored recipe vectors.
+- Recipe search combines PostgreSQL full-text search, `pg_trgm`, and stored embedding vectors in one hybrid ranking pass.
 - Health endpoint is lightweight by design and avoids DB/LLM dependencies.
 
 ## Related Docs

--- a/docs/frontend-api-contract.md
+++ b/docs/frontend-api-contract.md
@@ -38,7 +38,7 @@ client.
 
 ### 1) Semantic Search
 
-- Endpoint: `GET /api/v1/recipes/search/semantic?query=<string>&limit=<int>`
+- Endpoint: `GET /api/v1/recipes/search/semantic?query=<string>&limit=<int>` (legacy path name, hybrid behavior)
 - Response shape consumed by frontend:
 
 ```json


### PR DESCRIPTION
## Summary
- rename remaining internal search helpers, cache symbols, logs, and test helpers from `semantic` to `hybrid` where behavior is now Postgres hybrid search
- update README, engineering docs, frontend API contract notes, and homepage/search route copy to reflect hybrid search terminology
- keep the public `/api/v1/recipes/search/semantic` route unchanged for backward compatibility and document that explicitly

## Why
The search implementation was already migrated to PostgreSQL hybrid ranking, but a small amount of internal naming and user-facing copy still described the old semantic-search model. This PR removes that drift so the codebase and docs match the actual behavior.

## Impact
- no API contract change
- no behavior change intended
- clearer logs, docs, and test/client helper naming

## Validation
- [x] `./.venv/bin/python -m pytest app/tests/unit/test_recipe_semantic_search_endpoint.py app/tests/unit/test_experiment_service_guardrails.py`